### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server that provides AI assistants with comprehen
 
 **🆕 Now with ChatGPT Deep Research support!**
 
+<a href="https://glama.ai/mcp/servers/@Jameswlepage/trac-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Jameswlepage/trac-mcp/badge" alt="WordPress Trac Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server transforms WordPress Trac into an AI-accessible knowledge base, enabling intelligent queries about WordPress development, ticket tracking, and code changes. Features dual architecture supporting both standard MCP clients and ChatGPT's Deep Research requirements.


### PR DESCRIPTION
This PR adds a badge for the [WordPress Trac MCP Server](https://glama.ai/mcp/servers/@Jameswlepage/trac-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Jameswlepage/trac-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Jameswlepage/trac-mcp/badge" alt="WordPress Trac Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.