### PR TITLE
Fix getChangeset 403 by using the identifying user agent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -527,7 +527,7 @@ async function handleMcpRequest(request: any): Promise<any> {
               // Fetch changeset page
               const response = await fetch(changesetUrl, {
                 headers: {
-                  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+                  'User-Agent': 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)'
                 }
               });
 
@@ -581,7 +581,7 @@ async function handleMcpRequest(request: any): Promise<any> {
                   const diffUrl = `${changesetUrl}?format=diff`;
                   const diffResponse = await fetch(diffUrl, {
                     headers: {
-                      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+                      'User-Agent': 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)'
                     }
                   });
 
@@ -628,7 +628,7 @@ async function handleMcpRequest(request: any): Promise<any> {
               
               const response = await fetch(timelineUrl, {
                 headers: {
-                  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+                  'User-Agent': 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)'
                 }
               });
 
@@ -1227,7 +1227,7 @@ async function getChangesetForChatGPT(revision: number, includeDiff: boolean) {
     
     const response = await fetch(changesetUrl, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        'User-Agent': 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)'
       }
     });
 
@@ -1258,7 +1258,7 @@ async function getChangesetForChatGPT(revision: number, includeDiff: boolean) {
         const diffUrl = `${changesetUrl}?format=diff`;
         const diffResponse = await fetch(diffUrl, {
           headers: {
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+            'User-Agent': 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)'
           }
         });
 
@@ -1304,7 +1304,7 @@ async function getTimelineForChatGPT(days: number, limit: number) {
     
     const response = await fetch(timelineUrl, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        'User-Agent': 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)'
       }
     });
 


### PR DESCRIPTION
Fixes the 403 reported in #4, at least for the surface that is still blocked.

## What is happening

`core.trac.wordpress.org` returns 403 to clients that present a **spoofed browser** user agent, and 200 to clients that identify themselves.

Six `fetch` sites in `src/index.ts` still send a Chrome 91 string. Six others already send `Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)`. The ones that identify themselves work; the ones that pretend to be Chrome are refused. This PR makes the remaining six match.

## Verification

Against `/changeset/62850` today:

| User agent | Result |
| --- | --- |
| `...Chrome/91.0.4472.124 Safari/537.36` (current) | **403** |
| `Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)` | **200** |
| `curl/8.0` | 403 |
| empty | 403 |

So it is not that any non-browser agent passes. The identifying string is what gets through, which makes sense: a real browser would solve the challenge, so claiming to be one and then not solving it is the signal being blocked.

With the change, `getChangeset` returns real data again. Parsing the fetched page still works:

```
message: "KSES: Allow the autofocus attribute on dialog elements."
author:  "afercia"
```

`?format=diff` also returns 200, so `includeDiff` works too.

## Scope

- `getChangeset` and its diff sub-fetch, standard and ChatGPT variants. This is the actual fix.
- `getTimeline`, standard and ChatGPT variants. Unaffected in practice, because it requests RSS and RSS is not behind the wall, but it was sending the same spoofed string. Changed so it does not break if that changes.

This explains why #4 reported everything as broken in April while only changesets fail now: the tools using the identifying agent were never the problem, and RSS was never walled.

## Checks

`pnpm run type-check` passes. `pnpm run lint` reports 10 errors and 11 warnings, but identically on unmodified `main`, so they are pre-existing and untouched here.

## Not done here

The user agent is a string literal in twelve places, which is how six of them drifted. A shared constant would prevent a repeat, but I kept this diff to the fix. Happy to follow up if you want it.

Credit: Barry, for spotting that the two call sites disagreed.

