### PR TITLE
Fix searchTickets status documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Search through WordPress Trac tickets with intelligent filtering.
 }
 ```
 
-`status` takes a Trac status: `new`, `assigned`, `reopened`, or `closed`. There
-is no `open` status; passing one returns an empty result set rather than an
-error. Omit `status` to search every ticket.
+`status` takes a Trac status: `accepted`, `assigned`, `closed`, `new`,
+`reopened`, or `reviewing`. There is no `open` status; passing one returns an
+empty result set rather than an error. Omit `status` to search every ticket.
 
 #### getTicket
 Retrieve comprehensive information about specific tickets.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ Search through WordPress Trac tickets with intelligent filtering.
   "args": {
     "query": "REST API performance",
     "limit": 10,
-    "status": "open"
+    "status": "new"
   }
 }
 ```
+
+`status` takes a Trac status: `new`, `assigned`, `reopened`, or `closed`. There
+is no `open` status; passing one returns an empty result set rather than an
+error. Omit `status` to search every ticket.
 
 #### getTicket
 Retrieve comprehensive information about specific tickets.

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ async function handleMcpRequest(request: any): Promise<any> {
                   },
                   status: {
                     type: "string",
-                    description: "Filter by ticket status (e.g., 'open', 'closed', 'new')",
+                    description: "Filter by ticket status: accepted, assigned, closed, new, reopened, or reviewing",
                   },
                   component: {
                     type: "string", 


### PR DESCRIPTION
Fixes #7.

The `searchTickets` example passes `"status": "open"`. Trac has no status called `open`, so the example as written returns nothing.

```
searchTickets {"query": "REST API", "limit": 2}                    -> 2 results
searchTickets {"query": "REST API", "limit": 2, "status": "new"}   -> 2 results
searchTickets {"query": "REST API", "limit": 2, "status": "open"}  -> 0 results
```

An unrecognised status returns an empty result set rather than an error, so the failure is silent and self-consistent: it reads as "nothing matches your query" rather than "your filter is invalid." Copying the example is the most likely way to hit it, which is how I found it.

This switches the example to `new` and adds a line naming the valid values, since the empty-result behaviour is worth knowing about even once the example is correct.

The MCP tool schema now lists the same valid statuses. No runtime behavior changes.
