### PR TITLE
Fix Trac timeline date range

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,6 +31,7 @@ function mcpRequest(body: unknown, path = '/mcp') {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe('Trac parsing', () => {
@@ -152,6 +153,36 @@ describe('MCP transport', () => {
 
     expect(body.result.isError).toBe(true);
     expect(body.result.content.at(0)?.text).toContain('Unavailable');
+  });
+
+  it('requests timeline activity ending today across ticket and repository events', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-05T12:00:00Z'));
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('<?xml version="1.0"?><rss><channel></channel></rss>'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'getTimeline',
+        arguments: { days: 7, limit: 20 },
+      },
+    });
+
+    const timelineUrl = new URL(fetchMock.mock.calls[0]?.[0]?.toString() ?? '');
+    expect(Object.fromEntries(timelineUrl.searchParams)).toEqual({
+      from: '2026-08-05',
+      daysback: '7',
+      max: '20',
+      format: 'rss',
+      ticket: 'on',
+      ticket_details: 'on',
+      'repo-': 'on',
+    });
   });
 
   it('requires an r prefix for changesets on the compatibility endpoint', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -546,9 +546,13 @@ async function fetchTracInfo(type: TracInfoType): Promise<string[]> {
 
 async function fetchTimeline(days: number, limit: number) {
   const timelineUrl = new URL('https://core.trac.wordpress.org/timeline');
-  timelineUrl.searchParams.set('from', `${days} days ago`);
+  timelineUrl.searchParams.set('from', new Date().toISOString().slice(0, 10));
+  timelineUrl.searchParams.set('daysback', days.toString());
   timelineUrl.searchParams.set('max', limit.toString());
   timelineUrl.searchParams.set('format', 'rss');
+  timelineUrl.searchParams.set('ticket', 'on');
+  timelineUrl.searchParams.set('ticket_details', 'on');
+  timelineUrl.searchParams.set('repo-', 'on');
 
   const response = await fetch(timelineUrl.toString(), {
     headers: { 'User-Agent': TRAC_USER_AGENT },


### PR DESCRIPTION
## What changed

- Make the Trac timeline window end on the current date and use `daysback` to control its length.
- Request ticket creation, ticket update, and default repository events explicitly.
- Add coverage for every timeline query parameter.

## Why

Trac treats `from` as the end of the window. Passing `7 days ago` therefore returned activity ending seven days ago instead of activity from the last seven days. The previous request also omitted event selectors, which excluded useful ticket and repository activity.

## Testing

- `pnpm check`
- Started the Worker locally and confirmed `getTimeline` returned current-day activity from live Trac.
