### PR TITLE
Include linked pull requests in ticket results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ dry-run build. Follow `docs/testing.md` when a change affects live Trac parsing 
 - Keep advertised JSON schemas and Zod runtime schemas aligned.
 - Add or update tests for parser, protocol, routing, and pagination behavior.
 - Treat Trac responses as untrusted input.
-- Keep upstream requests on `core.trac.wordpress.org`.
+- Keep upstream requests on `core.trac.wordpress.org` and the official linked-PR endpoint at
+  `api.wordpress.org/dotorg/trac/pr/`.
 - Return upstream failures as MCP tool errors.
 - Update README and manual checks when behavior changes.
 - Do not deploy without explicit maintainer approval.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The standard `/mcp` endpoint provides:
 | Tool | Purpose |
 | --- | --- |
 | `searchTickets` | Search by keywords, ticket number, or structured filters |
-| `getTicket` | Read a ticket, its metadata, and recent comments |
+| `getTicket` | Read a ticket, its metadata, recent comments, and linked pull requests |
 | `getChangeset` | Read a changeset and an optional truncated diff |
 | `getTimeline` | Read recent Trac activity |
 | `getTracInfo` | List components, milestones, priorities, severities, types, or statuses |
@@ -92,7 +92,8 @@ pnpm deploy:production
 
 - The server is read-only and has no Trac credentials.
 - Tool inputs receive runtime validation before any upstream request.
-- Upstream requests use the fixed `core.trac.wordpress.org` host.
+- Upstream requests use the fixed `core.trac.wordpress.org` host and the official linked-PR
+  endpoint on `api.wordpress.org`.
 - Responses are parsed from public Trac pages and machine-readable formats.
 - The Worker keeps no ticket cache or durable state.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,7 @@ Start the Worker with `pnpm dev`, then use harmless public ticket and changeset 
 4. Exercise each standard tool:
    - Search a keyword and a structured filter.
    - Read ticket `65739` with and without comments.
+   - Read ticket `65808` and confirm its linked pull request data is present.
    - Read changeset `58504` with and without its diff.
    - Read one day of timeline activity.
    - List components and milestones.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -185,6 +185,78 @@ describe('MCP transport', () => {
     });
   });
 
+  it('includes linked pull request status, checks, reviews, and changes with a ticket', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+      .mockResolvedValueOnce(
+        new Response(
+          '<?xml version="1.0"?><rss><channel><description>Ticket description</description></channel></rss>'
+        )
+      )
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            number: 12833,
+            repo: 'WordPress/wordpress-develop',
+            state: 'closed',
+            title: 'REST API: Always register the media creation arguments',
+            user: {
+              name: 'contributor',
+              url: 'https://github.com/contributor',
+            },
+            created_at: '2026-08-04T07:18:35Z',
+            updated_at: '2026-08-05T06:41:21Z',
+            closed_at: '2026-08-05T06:41:21Z',
+            changes: {
+              additions: 234,
+              deletions: 45,
+              patch_url: 'https://github.com/WordPress/wordpress-develop/pull/12833.diff',
+              html_url: 'https://github.com/WordPress/wordpress-develop/pull/12833',
+            },
+            touches_tests: true,
+            check_runs: { 'GitHub Actions': 'success' },
+            reviews: { APPROVED: ['reviewer'] },
+            mergeable_state: 'blocked',
+            body: 'Pull request description',
+            html_url: 'https://github.com/WordPress/wordpress-develop/pull/12833',
+          },
+        ])
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'getTicket',
+        arguments: { id: 65808, includeComments: true, commentLimit: 10 },
+      },
+    });
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(fetchMock.mock.calls[2]?.[0]?.toString()).toBe(
+      'https://api.wordpress.org/dotorg/trac/pr/?trac=core&ticket=65808'
+    );
+    expect(result.metadata.linkedPullRequests).toEqual([
+      expect.objectContaining({
+        number: 12833,
+        repository: 'WordPress/wordpress-develop',
+        checkRuns: { 'GitHub Actions': 'success' },
+        reviews: { APPROVED: ['reviewer'] },
+        touchesTests: true,
+        additions: 234,
+        deletions: 45,
+      }),
+    ]);
+    expect(result.text).toContain('Linked pull requests:');
+    expect(result.text).toContain('CI: GitHub Actions: success');
+    expect(result.text).toContain('Reviews: APPROVED: reviewer');
+    expect(result.text).toContain('Pull request description');
+  });
+
   it('requires an r prefix for changesets on the compatibility endpoint', async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal('fetch', fetchMock);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -251,10 +251,50 @@ describe('MCP transport', () => {
         deletions: 45,
       }),
     ]);
+    expect(result.metadata.linkedPullRequestsUnavailable).toBe(false);
     expect(result.text).toContain('Linked pull requests:');
     expect(result.text).toContain('CI: GitHub Actions: success');
     expect(result.text).toContain('Reviews: APPROVED: reviewer');
     expect(result.text).toContain('Pull request description');
+  });
+
+  it.each([
+    [
+      'an HTTP error',
+      () => new Response('Unavailable', { status: 503, statusText: 'Unavailable' }),
+    ],
+    ['an unexpected response shape', () => Response.json([{ unexpected: 'shape' }])],
+  ])('keeps the ticket available when linked pull requests return %s', async (_label, response) => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+        .mockResolvedValueOnce(
+          new Response(
+            '<?xml version="1.0"?><rss><channel><description>Ticket description</description></channel></rss>'
+          )
+        )
+        .mockResolvedValueOnce(response())
+    );
+
+    const responseFromWorker = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'getTicket',
+        arguments: { id: 65808, includeComments: true, commentLimit: 10 },
+      },
+    });
+    const body = (await responseFromWorker.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(body.result.isError).not.toBe(true);
+    expect(result.title).toBe('#65808: REST API ticket');
+    expect(result.metadata.linkedPullRequests).toEqual([]);
+    expect(result.metadata.linkedPullRequestsUnavailable).toBe(true);
+    expect(result.text).toContain('Linked pull requests: unavailable');
   });
 
   it('requires an r prefix for changesets on the compatibility endpoint', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,31 @@ const ChatGptSearchArgsSchema = z.object({
 const ChatGptFetchArgsSchema = z.object({
   id: z.string().regex(/^(?:r\d+|\d+)$/, 'Use a ticket number or an r-prefixed changeset'),
 });
+const LinkedPullRequestSchema = z.object({
+  number: z.number().int().positive(),
+  repo: z.string(),
+  state: z.string(),
+  title: z.string(),
+  user: z.object({
+    name: z.string(),
+    url: z.string().url(),
+  }),
+  created_at: z.string(),
+  updated_at: z.string(),
+  closed_at: z.string().nullable(),
+  changes: z.object({
+    additions: z.number().int().nonnegative(),
+    deletions: z.number().int().nonnegative(),
+    patch_url: z.string().url(),
+    html_url: z.string().url(),
+  }),
+  touches_tests: z.boolean(),
+  check_runs: z.record(z.string()),
+  reviews: z.record(z.array(z.string())),
+  mergeable_state: z.string(),
+  body: z.string().nullable(),
+  html_url: z.string().url(),
+});
 
 class UnknownToolError extends Error {}
 
@@ -83,6 +108,27 @@ type TicketHistoryEntry = {
   changes: string;
   comment: string;
   url: string;
+};
+
+type LinkedPullRequest = {
+  number: number;
+  repository: string;
+  state: string;
+  title: string;
+  author: string;
+  authorUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  additions: number;
+  deletions: number;
+  touchesTests: boolean;
+  checkRuns: Record<string, string>;
+  reviews: Record<string, string[]>;
+  mergeableState: string;
+  patchUrl: string;
+  url: string;
+  body: string;
 };
 
 const HTML_ENTITIES: Record<string, string> = {
@@ -261,6 +307,46 @@ function ticketFromRecord(record: TracRecord) {
   };
 }
 
+async function fetchLinkedPullRequests(ticketId: number): Promise<LinkedPullRequest[]> {
+  const pullRequestsUrl = new URL('https://api.wordpress.org/dotorg/trac/pr/');
+  pullRequestsUrl.searchParams.set('trac', 'core');
+  pullRequestsUrl.searchParams.set('ticket', ticketId.toString());
+
+  const response = await fetch(pullRequestsUrl.toString(), {
+    headers: {
+      'User-Agent': TRAC_USER_AGENT,
+      Accept: 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch linked pull requests: ${response.statusText}`);
+  }
+
+  return z
+    .array(LinkedPullRequestSchema)
+    .parse(await response.json())
+    .map((pullRequest) => ({
+      number: pullRequest.number,
+      repository: pullRequest.repo,
+      state: pullRequest.state,
+      title: pullRequest.title,
+      author: pullRequest.user.name,
+      authorUrl: pullRequest.user.url,
+      createdAt: pullRequest.created_at,
+      updatedAt: pullRequest.updated_at,
+      closedAt: pullRequest.closed_at,
+      additions: pullRequest.changes.additions,
+      deletions: pullRequest.changes.deletions,
+      touchesTests: pullRequest.touches_tests,
+      checkRuns: pullRequest.check_runs,
+      reviews: pullRequest.reviews,
+      mergeableState: pullRequest.mergeable_state,
+      patchUrl: pullRequest.changes.patch_url,
+      url: pullRequest.html_url,
+      body: pullRequest.body ?? '',
+    }));
+}
+
 export async function searchTracTickets(
   query: string,
   limit: number,
@@ -336,9 +422,10 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   addColumns(queryUrl, TICKET_COLUMNS);
 
   const rssUrl = `https://core.trac.wordpress.org/ticket/${ticketId}?format=rss`;
-  const [records, rssResponse] = await Promise.all([
+  const [records, rssResponse, linkedPullRequests] = await Promise.all([
     fetchCsvRecords(queryUrl),
     fetch(rssUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
+    fetchLinkedPullRequests(ticketId),
   ]);
 
   const record = records.find((candidate) => Number.parseInt(candidate.id ?? '', 10) === ticketId);
@@ -364,7 +451,7 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   const comments = includeComments && limit > 0 ? allHistory.slice(-limit) : [];
   const ticket = { ...ticketFromRecord(record), description };
 
-  return { ticket, comments, totalComments: allHistory.length };
+  return { ticket, comments, totalComments: allHistory.length, linkedPullRequests };
 }
 
 function formatTicketResult(
@@ -372,7 +459,7 @@ function formatTicketResult(
   includeComments: boolean,
   stringId = false
 ) {
-  const { ticket, comments, totalComments } = ticketData;
+  const { ticket, comments, totalComments, linkedPullRequests } = ticketData;
   const historyText =
     includeComments && comments.length > 0
       ? `\n\nRecent history:\n${comments
@@ -384,6 +471,28 @@ function formatTicketResult(
           })
           .join('\n\n')}`
       : '';
+  const linkedPullRequestsText = linkedPullRequests.length
+    ? `\n\nLinked pull requests:\n${linkedPullRequests
+        .map((pullRequest) => {
+          const checks = Object.entries(pullRequest.checkRuns)
+            .map(([name, status]) => `${name}: ${status}`)
+            .join(', ');
+          const reviews = Object.entries(pullRequest.reviews)
+            .map(([verdict, reviewers]) => `${verdict}: ${reviewers.join(', ')}`)
+            .join('; ');
+          return `${pullRequest.repository}#${pullRequest.number}: ${pullRequest.title}
+State: ${pullRequest.state}
+Author: ${pullRequest.author}
+CI: ${checks || 'No check results'}
+Reviews: ${reviews || 'No reviews'}
+Touches tests: ${pullRequest.touchesTests ? 'yes' : 'no'}
+Changes: +${pullRequest.additions}/-${pullRequest.deletions}
+URL: ${pullRequest.url}
+
+${pullRequest.body || 'No pull request description'}`;
+        })
+        .join('\n\n')}`
+    : '';
 
   return {
     id: stringId ? ticket.id.toString() : ticket.id,
@@ -404,13 +513,14 @@ Keywords: ${ticket.keywords}
 Focuses: ${ticket.focuses}
 
 Description:
-${ticket.description}${historyText}`,
+${ticket.description}${linkedPullRequestsText}${historyText}`,
     url: `https://core.trac.wordpress.org/ticket/${ticket.id}`,
     metadata: {
       ticket,
       comments,
       totalComments,
       returnedComments: comments.length,
+      linkedPullRequests,
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,10 +422,12 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   addColumns(queryUrl, TICKET_COLUMNS);
 
   const rssUrl = `https://core.trac.wordpress.org/ticket/${ticketId}?format=rss`;
-  const [records, rssResponse, linkedPullRequests] = await Promise.all([
+  const [records, rssResponse, linkedPullRequestsResult] = await Promise.all([
     fetchCsvRecords(queryUrl),
     fetch(rssUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
-    fetchLinkedPullRequests(ticketId),
+    fetchLinkedPullRequests(ticketId)
+      .then((linkedPullRequests) => ({ linkedPullRequests, unavailable: false }))
+      .catch(() => ({ linkedPullRequests: [], unavailable: true })),
   ]);
 
   const record = records.find((candidate) => Number.parseInt(candidate.id ?? '', 10) === ticketId);
@@ -451,7 +453,13 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   const comments = includeComments && limit > 0 ? allHistory.slice(-limit) : [];
   const ticket = { ...ticketFromRecord(record), description };
 
-  return { ticket, comments, totalComments: allHistory.length, linkedPullRequests };
+  return {
+    ticket,
+    comments,
+    totalComments: allHistory.length,
+    linkedPullRequests: linkedPullRequestsResult.linkedPullRequests,
+    linkedPullRequestsUnavailable: linkedPullRequestsResult.unavailable,
+  };
 }
 
 function formatTicketResult(
@@ -459,7 +467,8 @@ function formatTicketResult(
   includeComments: boolean,
   stringId = false
 ) {
-  const { ticket, comments, totalComments, linkedPullRequests } = ticketData;
+  const { ticket, comments, totalComments, linkedPullRequests, linkedPullRequestsUnavailable } =
+    ticketData;
   const historyText =
     includeComments && comments.length > 0
       ? `\n\nRecent history:\n${comments
@@ -471,16 +480,18 @@ function formatTicketResult(
           })
           .join('\n\n')}`
       : '';
-  const linkedPullRequestsText = linkedPullRequests.length
-    ? `\n\nLinked pull requests:\n${linkedPullRequests
-        .map((pullRequest) => {
-          const checks = Object.entries(pullRequest.checkRuns)
-            .map(([name, status]) => `${name}: ${status}`)
-            .join(', ');
-          const reviews = Object.entries(pullRequest.reviews)
-            .map(([verdict, reviewers]) => `${verdict}: ${reviewers.join(', ')}`)
-            .join('; ');
-          return `${pullRequest.repository}#${pullRequest.number}: ${pullRequest.title}
+  const linkedPullRequestsText = linkedPullRequestsUnavailable
+    ? '\n\nLinked pull requests: unavailable'
+    : linkedPullRequests.length
+      ? `\n\nLinked pull requests:\n${linkedPullRequests
+          .map((pullRequest) => {
+            const checks = Object.entries(pullRequest.checkRuns)
+              .map(([name, status]) => `${name}: ${status}`)
+              .join(', ');
+            const reviews = Object.entries(pullRequest.reviews)
+              .map(([verdict, reviewers]) => `${verdict}: ${reviewers.join(', ')}`)
+              .join('; ');
+            return `${pullRequest.repository}#${pullRequest.number}: ${pullRequest.title}
 State: ${pullRequest.state}
 Author: ${pullRequest.author}
 CI: ${checks || 'No check results'}
@@ -490,9 +501,9 @@ Changes: +${pullRequest.additions}/-${pullRequest.deletions}
 URL: ${pullRequest.url}
 
 ${pullRequest.body || 'No pull request description'}`;
-        })
-        .join('\n\n')}`
-    : '';
+          })
+          .join('\n\n')}`
+      : '';
 
   return {
     id: stringId ? ticket.id.toString() : ticket.id,
@@ -521,6 +532,7 @@ ${ticket.description}${linkedPullRequestsText}${historyText}`,
       totalComments,
       returnedComments: comments.length,
       linkedPullRequests,
+      linkedPullRequestsUnavailable,
     },
   };
 }


### PR DESCRIPTION
## What changed

- Fetch linked GitHub pull requests from the official WordPress.org endpoint alongside ticket metadata and history.
- Return normalized PR status, author, dates, change counts, test coverage, CI checks, reviews, mergeability, links, and body text.
- Validate the upstream JSON before exposing it through `getTicket`.
- Document the additional fixed WordPress.org host and add a live-test case.

## Why

Trac tickets often use GitHub pull requests as their current patches. `getTicket` previously could not say whether a patch existed, whether CI passed, who approved it, or whether it changed tests.

## Testing

- `pnpm check`
- Started the Worker locally and confirmed ticket 65808 returned its linked WordPress/wordpress-develop pull request with live CI, review, test, and change metadata.
