### PR TITLE
Classify ticket attachments, changesets, and discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The standard `/mcp` endpoint provides:
 | Tool | Purpose |
 | --- | --- |
 | `searchTickets` | Search by keywords, ticket number, or structured filters |
-| `getTicket` | Read a ticket, its metadata, recent comments, and linked pull requests |
+| `getTicket` | Read a ticket, its attachments, changesets, recent human discussion, and linked pull requests |
 | `getChangeset` | Read a changeset and an optional truncated diff |
 | `getTimeline` | Read recent Trac activity |
 | `getTracInfo` | List components, milestones, priorities, severities, types, or statuses |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,8 @@ Start the Worker with `pnpm dev`, then use harmless public ticket and changeset 
    - Search a keyword and a structured filter.
    - Read ticket `65739` with and without comments.
    - Read ticket `65808` and confirm its linked pull request data is present.
+   - Read ticket `65793` and confirm attachments are separate from comments.
+   - Read ticket `62358` and confirm changesets are separate from comments.
    - Read changeset `58504` with and without its diff.
    - Read one day of timeline activity.
    - List components and milestones.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -297,6 +297,60 @@ describe('MCP transport', () => {
     expect(result.text).toContain('Linked pull requests: unavailable');
   });
 
+  it('separates attachments and changesets before limiting real comments', async () => {
+    const rss = `<?xml version="1.0"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/"><channel>
+      <description>Ticket description</description>
+      <item><dc:creator>contributor</dc:creator><pubDate>Mon, 03 Aug 2026 10:42:01 GMT</pubDate><title>attachment set</title><link>https://core.trac.wordpress.org/ticket/65793</link><description>&lt;ul&gt;&lt;li&gt;&lt;strong&gt;attachment&lt;/strong&gt; → &lt;span class=&quot;trac-field-new&quot;&gt;01 example.png&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;</description></item>
+      <item><dc:creator>committer</dc:creator><pubDate>Thu, 07 Nov 2024 16:03:41 GMT</pubDate><title>status changed; resolution set</title><link>https://core.trac.wordpress.org/ticket/65793#comment:4</link><description>&lt;ul&gt;&lt;li&gt;&lt;strong&gt;status&lt;/strong&gt; closed&lt;/li&gt;&lt;li&gt;&lt;strong&gt;resolution&lt;/strong&gt; fixed&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;In &lt;a class=&quot;changeset&quot; href=&quot;https://core.trac.wordpress.org/changeset/59369&quot;&gt;59369&lt;/a&gt;:&lt;/p&gt;&lt;div class=&quot;message&quot;&gt;&lt;p&gt;Backport message.&lt;/p&gt;&lt;/div&gt;</description></item>
+      <item><dc:creator>reviewer</dc:creator><pubDate>Wed, 05 Aug 2026 19:00:00 GMT</pubDate><title></title><link>https://core.trac.wordpress.org/ticket/65793#comment:5</link><description>&lt;p&gt;Useful review comment.&lt;/p&gt;</description></item>
+      <item><dc:creator>reviewer</dc:creator><pubDate>Wed, 05 Aug 2026 19:01:00 GMT</pubDate><title>keywords set</title><link>https://core.trac.wordpress.org/ticket/65793#comment:6</link><description>&lt;ul&gt;&lt;li&gt;&lt;strong&gt;keywords&lt;/strong&gt; needs-testing added&lt;/li&gt;&lt;/ul&gt;</description></item>
+      <item><dc:creator>reporter</dc:creator><pubDate>Wed, 05 Aug 2026 19:02:00 GMT</pubDate><title>description changed</title><link>https://core.trac.wordpress.org/ticket/65793#description</link><description>&lt;p&gt;Ticket description repeated.&lt;/p&gt;</description></item>
+      <item><dc:creator>slackbot</dc:creator><pubDate>Wed, 05 Aug 2026 19:03:00 GMT</pubDate><title></title><link>https://core.trac.wordpress.org/ticket/65793#comment:7</link><description>&lt;p&gt;Slack mention.&lt;/p&gt;</description></item>
+      <item><dc:creator>prbot</dc:creator><pubDate>Wed, 05 Aug 2026 19:04:00 GMT</pubDate><title></title><link>https://core.trac.wordpress.org/ticket/65793#comment:8</link><description>&lt;p&gt;Pull request relay.&lt;/p&gt;</description></item>
+    </channel></rss>`;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('id,summary,status\n65793,Accessibility ticket,new'))
+      .mockResolvedValueOnce(new Response(rss));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'getTicket',
+        arguments: { id: 65793, includeComments: true, commentLimit: 1 },
+      },
+    });
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(result.metadata.attachments).toEqual([
+      expect.objectContaining({
+        filename: '01 example.png',
+        url: 'https://core.trac.wordpress.org/raw-attachment/ticket/65793/01%20example.png',
+      }),
+    ]);
+    expect(result.metadata.changesets).toEqual([
+      expect.objectContaining({
+        revision: 59369,
+        message: 'Backport message.',
+        url: 'https://core.trac.wordpress.org/changeset/59369',
+      }),
+    ]);
+    expect(result.metadata.comments).toEqual([
+      expect.objectContaining({ id: 5, author: 'reviewer', comment: 'Useful review comment.' }),
+    ]);
+    expect(result.metadata.totalComments).toBe(1);
+    expect(result.text).toContain('Attachments:');
+    expect(result.text).toContain('Changesets:');
+    expect(result.text).toContain('Recent comments:');
+    expect(result.text).not.toContain('Slack mention.');
+    expect(result.text).not.toContain('Pull request relay.');
+    expect(result.text).not.toContain('Ticket description repeated.');
+  });
+
   it('requires an r prefix for changesets on the compatibility endpoint', async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal('fetch', fetchMock);

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,23 @@ type LinkedPullRequest = {
   body: string;
 };
 
+type TicketAttachment = {
+  filename: string;
+  author: string;
+  timestamp: string;
+  description: string;
+  url: string;
+};
+
+type TicketChangeset = {
+  revision: number;
+  author: string;
+  timestamp: string;
+  changes: string;
+  message: string;
+  url: string;
+};
+
 const HTML_ENTITIES: Record<string, string> = {
   amp: '&',
   apos: "'",
@@ -197,10 +214,172 @@ function parseRssItems(rssText: string) {
       title: cleanTracText(extractXmlElement(item, 'title')),
       link: cleanTracText(extractXmlElement(item, 'link')),
       description: cleanTracText(extractXmlElement(item, 'description')),
+      rawDescription: extractXmlElement(item, 'description'),
       date: cleanTracText(extractXmlElement(item, 'pubDate')),
       author: cleanTracText(extractXmlElement(item, 'dc:creator')),
     };
   });
+}
+
+const TICKET_FIELDS = new Set([
+  'attachment',
+  'cc',
+  'component',
+  'description',
+  'focuses',
+  'keywords',
+  'milestone',
+  'owner',
+  'priority',
+  'reporter',
+  'resolution',
+  'severity',
+  'status',
+  'summary',
+  'type',
+  'version',
+]);
+
+function splitTicketHistoryDescription(rawDescription: string) {
+  const html = decodeHtmlEntities(rawDescription);
+  const list = html.match(/^\s*<ul(?:\s[^>]*)?>([\s\S]*?)<\/ul>\s*/i);
+  if (!list?.[0] || !list[1]) {
+    return { html, body: cleanTracText(html) };
+  }
+
+  const items = Array.from(list[1].matchAll(/<li(?:\s[^>]*)?>[\s\S]*?<\/li>/gi), (match) =>
+    match[0]
+      .match(/<strong(?:\s[^>]*)?>([^<]+)<\/strong>/i)?.[1]
+      ?.trim()
+      .toLowerCase()
+  );
+  const unmatched = list[1].replace(/<li(?:\s[^>]*)?>[\s\S]*?<\/li>/gi, '').trim();
+  if (
+    unmatched ||
+    items.length === 0 ||
+    items.some((field) => !field || !TICKET_FIELDS.has(field))
+  ) {
+    return { html, body: cleanTracText(html) };
+  }
+
+  const narrativeHtml = html.slice(list[0].length);
+  return { html, body: cleanTracText(narrativeHtml), narrativeHtml };
+}
+
+function filterTicketFieldChurn(changes: string): string {
+  return changes
+    .split(';')
+    .map((clause) => {
+      const match = clause.trim().match(/^(.+?)\s+(set|changed|deleted)$/i);
+      if (!match?.[1] || !match[2]) {
+        return clause.trim();
+      }
+      const fields = match[1]
+        .split(',')
+        .map((field) => field.trim())
+        .filter((field) => !['cc', 'keywords'].includes(field.toLowerCase()));
+      return fields.length ? `${fields.join(', ')} ${match[2]}` : '';
+    })
+    .filter(Boolean)
+    .join('; ');
+}
+
+function attachmentFilename(html: string): string {
+  const emphasized = html.match(/<em(?:\s[^>]*)?>([\s\S]*?)<\/em>/i)?.[1];
+  const fieldValue = html.match(
+    /<strong(?:\s[^>]*)?>\s*attachment\s*<\/strong>[\s\S]*?<span\s+class=["']trac-field-new["'][^>]*>([\s\S]*?)<\/span>/i
+  )?.[1];
+  return cleanTracText(emphasized ?? fieldValue ?? '');
+}
+
+type RssItem = ReturnType<typeof parseRssItems>[number];
+type ClassifiedTicketHistory =
+  | { kind: 'attachment'; entry: TicketAttachment }
+  | { kind: 'changeset'; entry: TicketChangeset }
+  | { kind: 'comment'; entry: TicketHistoryEntry };
+
+function classifyTicketHistoryItem(
+  ticketId: number,
+  item: RssItem
+): ClassifiedTicketHistory | null {
+  if (
+    ['prbot', 'slackbot'].includes(item.author.toLowerCase()) ||
+    /#description$/.test(item.link)
+  ) {
+    return null;
+  }
+
+  const parsedDescription = splitTicketHistoryDescription(item.rawDescription);
+  if (item.title.toLowerCase() === 'attachment set') {
+    const filename = attachmentFilename(parsedDescription.html);
+    return {
+      kind: 'attachment',
+      entry: {
+        filename,
+        author: item.author,
+        timestamp: item.date,
+        description: parsedDescription.body,
+        url: filename
+          ? `https://core.trac.wordpress.org/raw-attachment/ticket/${ticketId}/${encodeURIComponent(filename)}`
+          : '',
+      },
+    };
+  }
+
+  const narrativeHtml = parsedDescription.narrativeHtml ?? parsedDescription.html;
+  const changesetMatch = narrativeHtml.match(
+    /^\s*<p>\s*In\s*<a\b(?=[^>]*\bclass=["'][^"']*\bchangeset\b[^"']*["'])[^>]*>\[?(\d+)\]?<\/a>\s*:?\s*<\/p>\s*/i
+  );
+  if (changesetMatch?.[1]) {
+    const revision = Number.parseInt(changesetMatch[1], 10);
+    return {
+      kind: 'changeset',
+      entry: {
+        revision,
+        author: item.author,
+        timestamp: item.date,
+        changes: filterTicketFieldChurn(item.title),
+        message: cleanTracText(narrativeHtml.slice(changesetMatch[0].length)),
+        url: `https://core.trac.wordpress.org/changeset/${revision}`,
+      },
+    };
+  }
+
+  const changes = filterTicketFieldChurn(item.title);
+  if (!changes && !parsedDescription.body) {
+    return null;
+  }
+  const commentId = item.link.match(/#comment:(\d+)/)?.[1];
+  return {
+    kind: 'comment',
+    entry: {
+      id: commentId ? Number.parseInt(commentId, 10) : null,
+      author: item.author,
+      timestamp: item.date,
+      changes,
+      comment: parsedDescription.body,
+      url: item.link,
+    },
+  };
+}
+
+function classifyTicketHistory(ticketId: number, rssText: string) {
+  const comments: TicketHistoryEntry[] = [];
+  const attachments: TicketAttachment[] = [];
+  const changesets: TicketChangeset[] = [];
+
+  for (const item of parseRssItems(rssText)) {
+    const classified = classifyTicketHistoryItem(ticketId, item);
+    if (classified?.kind === 'comment') {
+      comments.push(classified.entry);
+    } else if (classified?.kind === 'attachment') {
+      attachments.push(classified.entry);
+    } else if (classified?.kind === 'changeset') {
+      changesets.push(classified.entry);
+    }
+  }
+
+  return { comments, attachments, changesets };
 }
 
 export function parseCsvRecords(csvData: string): TracRecord[] {
@@ -438,27 +617,19 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   const rssText = await rssResponse.text();
   const channel = rssText.split(/<item>/i, 1)[0] ?? '';
   const description = cleanTracText(extractXmlElement(channel, 'description'));
-  const allHistory: TicketHistoryEntry[] = parseRssItems(rssText).map((item) => {
-    const commentId = item.link.match(/#comment:(\d+)/)?.[1];
-    return {
-      id: commentId ? Number.parseInt(commentId, 10) : null,
-      author: item.author,
-      timestamp: item.date,
-      changes: item.title,
-      comment: item.description,
-      url: item.link,
-    };
-  });
+  const history = classifyTicketHistory(ticketId, rssText);
   const limit = Math.min(Math.max(Math.trunc(commentLimit), 0), 50);
-  const comments = includeComments && limit > 0 ? allHistory.slice(-limit) : [];
+  const comments = includeComments && limit > 0 ? history.comments.slice(-limit) : [];
   const ticket = { ...ticketFromRecord(record), description };
 
   return {
     ticket,
     comments,
-    totalComments: allHistory.length,
+    totalComments: history.comments.length,
     linkedPullRequests: linkedPullRequestsResult.linkedPullRequests,
     linkedPullRequestsUnavailable: linkedPullRequestsResult.unavailable,
+    attachments: history.attachments,
+    changesets: history.changesets,
   };
 }
 
@@ -467,11 +638,18 @@ function formatTicketResult(
   includeComments: boolean,
   stringId = false
 ) {
-  const { ticket, comments, totalComments, linkedPullRequests, linkedPullRequestsUnavailable } =
-    ticketData;
+  const {
+    ticket,
+    comments,
+    totalComments,
+    linkedPullRequests,
+    linkedPullRequestsUnavailable,
+    attachments,
+    changesets,
+  } = ticketData;
   const historyText =
     includeComments && comments.length > 0
-      ? `\n\nRecent history:\n${comments
+      ? `\n\nRecent comments:\n${comments
           .map((entry) => {
             const heading = [entry.timestamp, entry.author, entry.changes]
               .filter(Boolean)
@@ -504,6 +682,23 @@ ${pullRequest.body || 'No pull request description'}`;
           })
           .join('\n\n')}`
       : '';
+  const attachmentsText = attachments.length
+    ? `\n\nAttachments:\n${attachments
+        .map((attachment) => {
+          const details = [attachment.author, attachment.timestamp].filter(Boolean).join(' — ');
+          const descriptionText = attachment.description ? `\n${attachment.description}` : '';
+          return `- ${attachment.filename || '(unnamed)'}${details ? ` — ${details}` : ''}${attachment.url ? `\n  ${attachment.url}` : ''}${descriptionText}`;
+        })
+        .join('\n')}`
+    : '';
+  const changesetsText = changesets.length
+    ? `\n\nChangesets:\n${changesets
+        .map((changeset) => {
+          const details = [changeset.author, changeset.timestamp].filter(Boolean).join(' — ');
+          return `- r${changeset.revision}${details ? ` — ${details}` : ''}\n  ${changeset.url}${changeset.message ? `\n${changeset.message}` : ''}`;
+        })
+        .join('\n\n')}`
+    : '';
 
   return {
     id: stringId ? ticket.id.toString() : ticket.id,
@@ -524,7 +719,7 @@ Keywords: ${ticket.keywords}
 Focuses: ${ticket.focuses}
 
 Description:
-${ticket.description}${linkedPullRequestsText}${historyText}`,
+${ticket.description}${linkedPullRequestsText}${attachmentsText}${changesetsText}${historyText}`,
     url: `https://core.trac.wordpress.org/ticket/${ticket.id}`,
     metadata: {
       ticket,
@@ -533,6 +728,8 @@ ${ticket.description}${linkedPullRequestsText}${historyText}`,
       returnedComments: comments.length,
       linkedPullRequests,
       linkedPullRequestsUnavailable,
+      attachments,
+      changesets,
     },
   };
 }


### PR DESCRIPTION
Builds on #18’s canonical linked-pull-request section, then removes `prbot` relays from discussion.

## What changed

- Separate RSS attachment events into structured attachment data with canonical raw-file URLs.
- Separate changeset auto-comments into structured revision, author, date, message, and URL data.
- Remove `slackbot`, `prbot`, repeated description edits, and standalone cc/keyword churn from discussion.
- Apply `commentLimit` after classification so automation cannot displace human comments.
- Preserve meaningful field changes while removing cc and keyword noise.

## Why

`getTicket` previously flattened every RSS event into one comment stream. Attachments and commits were hard to find, while automation at the end of the feed displaced real discussion from the default ten-comment window.

## Testing

- `pnpm check`
- Confirmed ticket 65793 returns its attachment separately with two human comments and no bot relays.
- Confirmed ticket 62358 returns changeset r59369 separately with its full commit message.
- Confirmed ticket 65808 retains linked pull request data from #18.