### PR TITLE
Retry transient Trac request failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ pnpm deploy:production
 - Tool inputs receive runtime validation before any upstream request.
 - Upstream requests use the fixed `core.trac.wordpress.org` host and the official linked-PR
   endpoint on `api.wordpress.org`.
+- Transient transport failures, rate limits, server errors, and Trac bot challenges receive bounded
+  retries. Permanent 403 and 404 responses return immediately.
 - Responses are parsed from public Trac pages and machine-readable formats.
 - The Worker keeps no ticket cache or durable state.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import worker, {
   addTicketSearchQuery,
   cleanTracText,
+  fetchTrac,
   parseCsvRecords,
   parseTicketFilter,
   searchTracTickets,
@@ -60,7 +61,7 @@ describe('ticket search pagination', () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(''))
-      .mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }));
+      .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(searchTracTickets('', 10, 85)).resolves.toEqual({
@@ -71,6 +72,65 @@ describe('ticket search pagination', () => {
       pageSize: 10,
       hasMore: false,
     });
+  });
+});
+
+describe('Trac retries', () => {
+  it('retries transport failures, rate limits, server failures, and bot challenges', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError('network reset'))
+      .mockResolvedValueOnce(new Response('Rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response('Unavailable', { status: 503 }))
+      .mockResolvedValueOnce(new Response('<html>Checking your browser</html>', { status: 403 }))
+      .mockResolvedValueOnce(new Response('ok'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchTrac(
+      'https://core.trac.wordpress.org/timeline',
+      undefined,
+      [0, 0, 0, 0]
+    );
+
+    expect(await response.text()).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it.each([
+    [403, 'Forbidden'],
+    [404, 'Not Found'],
+  ])('does not retry a permanent HTTP %i response', async (status, statusText) => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(statusText, { status, statusText }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchTrac('https://core.trac.wordpress.org/timeline', undefined, [0]);
+
+    expect(response.status).toBe(status);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns the final transient response after exhausting retries', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('Unavailable', { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchTrac('https://core.trac.wordpress.org/timeline', undefined, [0, 0]);
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('refuses requests outside the fixed Trac origin', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchTrac('https://example.com/timeline', undefined, [0])).rejects.toThrow(
+      'Refusing non-Trac request host'
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 
@@ -137,7 +197,7 @@ describe('MCP transport', () => {
       'fetch',
       vi
         .fn<typeof fetch>()
-        .mockResolvedValue(new Response('Unavailable', { status: 503, statusText: 'Unavailable' }))
+        .mockResolvedValue(new Response('Forbidden', { status: 403, statusText: 'Forbidden' }))
     );
 
     const response = await mcpRequest({
@@ -152,7 +212,7 @@ describe('MCP transport', () => {
     const body = (await response.json()) as RpcBody;
 
     expect(body.result.isError).toBe(true);
-    expect(body.result.content.at(0)?.text).toContain('Unavailable');
+    expect(body.result.content.at(0)?.text).toContain('Forbidden');
   });
 
   it('requests timeline activity ending today across ticket and repository events', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ const LinkedPullRequestSchema = z.object({
 class UnknownToolError extends Error {}
 
 const TRAC_USER_AGENT = 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)';
+const TRAC_ORIGIN = 'https://core.trac.wordpress.org';
+const TRAC_RETRY_DELAYS_MS = [2000, 4000, 8000] as const;
 const TICKET_COLUMNS = [
   'id',
   'summary',
@@ -100,6 +102,47 @@ type TicketSearchFilters = {
   milestone?: string | undefined;
   resolution?: string | undefined;
 };
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function isTransientTracResponse(response: Response): Promise<boolean> {
+  if (response.status === 429 || response.status >= 500) {
+    return true;
+  }
+  if (response.status !== 403) {
+    return false;
+  }
+
+  return /Checking your browser/i.test(await response.clone().text());
+}
+
+export async function fetchTrac(
+  input: string | URL,
+  init?: RequestInit,
+  retryDelays: readonly number[] = TRAC_RETRY_DELAYS_MS
+): Promise<Response> {
+  const url = new URL(input);
+  if (url.origin !== TRAC_ORIGIN) {
+    throw new Error(`Refusing non-Trac request host: ${url.hostname}`);
+  }
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const response = await fetch(url.toString(), init);
+      if (!(await isTransientTracResponse(response)) || attempt >= retryDelays.length) {
+        return response;
+      }
+    } catch (error) {
+      if (attempt >= retryDelays.length) {
+        throw error;
+      }
+    }
+
+    await wait(retryDelays[attempt] ?? 0);
+  }
+}
 
 type TicketHistoryEntry = {
   id: number | null;
@@ -446,7 +489,7 @@ export function addTicketSearchQuery(url: URL, query: string): void {
 }
 
 async function fetchCsvRecords(url: URL): Promise<TracRecord[]> {
-  const response = await fetch(url.toString(), {
+  const response = await fetchTrac(url, {
     headers: {
       'User-Agent': TRAC_USER_AGENT,
       Accept: 'text/csv,text/plain,*/*',
@@ -562,7 +605,7 @@ export async function searchTracTickets(
   totalUrl.searchParams.delete('page');
   const [records, totalResponse] = await Promise.all([
     fetchCsvRecords(queryUrl),
-    fetch(totalUrl.toString(), { headers: { 'User-Agent': TRAC_USER_AGENT } }),
+    fetchTrac(totalUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
   ]);
   const tickets = records.map(ticketFromRecord);
   if (!totalResponse.ok) {
@@ -603,7 +646,7 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   const rssUrl = `https://core.trac.wordpress.org/ticket/${ticketId}?format=rss`;
   const [records, rssResponse, linkedPullRequestsResult] = await Promise.all([
     fetchCsvRecords(queryUrl),
-    fetch(rssUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
+    fetchTrac(rssUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
     fetchLinkedPullRequests(ticketId)
       .then((linkedPullRequests) => ({ linkedPullRequests, unavailable: false }))
       .catch(() => ({ linkedPullRequests: [], unavailable: true })),
@@ -736,7 +779,7 @@ ${ticket.description}${linkedPullRequestsText}${attachmentsText}${changesetsText
 
 async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit = 2000) {
   const changesetUrl = `https://core.trac.wordpress.org/changeset/${revision}`;
-  const response = await fetch(changesetUrl, {
+  const response = await fetchTrac(changesetUrl, {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
 
@@ -762,7 +805,7 @@ async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit 
   let diff = '';
   if (includeDiff) {
     try {
-      const diffResponse = await fetch(`${changesetUrl}?format=diff`, {
+      const diffResponse = await fetchTrac(`${changesetUrl}?format=diff`, {
         headers: { 'User-Agent': TRAC_USER_AGENT },
       });
       if (diffResponse.ok) {
@@ -811,7 +854,7 @@ ${changeset.diff ? `Diff:\n${changeset.diff}` : 'No diff available'}`,
 async function fetchTracFieldOptions(field: 'component' | 'severity'): Promise<string[]> {
   const queryUrl = new URL('https://core.trac.wordpress.org/query');
   queryUrl.searchParams.set(field, '');
-  const response = await fetch(queryUrl.toString(), {
+  const response = await fetchTrac(queryUrl, {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
 
@@ -873,7 +916,7 @@ async function fetchTimeline(days: number, limit: number) {
   timelineUrl.searchParams.set('ticket_details', 'on');
   timelineUrl.searchParams.set('repo-', 'on');
 
-  const response = await fetch(timelineUrl.toString(), {
+  const response = await fetchTrac(timelineUrl, {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
   if (!response.ok) {


### PR DESCRIPTION
## What changed

- Route every request to Core Trac through one fixed-origin fetch helper.
- Retry transport failures, HTTP 429, HTTP 5xx, and the specific 403 “Checking your browser” challenge.
- Use bounded 2-, 4-, and 8-second backoff delays.
- Return ordinary 403 and 404 responses immediately.
- Add coverage for successful retries, exhausted retries, permanent errors, and rejected hosts.

## Why

Core Trac sometimes serves a temporary browser-check page or brief server failure. The server previously returned those transient responses as hard tool errors, forcing callers to retry the entire operation themselves.

## Testing

- `pnpm check`
- Confirmed `getTracInfo` retrieved the current 68 Core components through the shared fetch helper.
- Confirmed ticket 65808 retained its linked pull request and classified changeset after rebasing onto #19.