### PR TITLE
Document production MCP usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,23 @@ A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server fo
 [WordPress Core Trac](https://core.trac.wordpress.org/). It runs as a Cloudflare Worker and uses
 Trac's public HTML, CSV, RSS, and diff endpoints.
 
-Live server:
+Live servers:
+
+Production:
 
 - Standard MCP: `https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp`
 - Search/fetch compatibility: `https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp/chatgpt`
 - Health check: `https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/health`
+
+Staging:
+
+- Standard MCP: `https://mcp-server-wporg-trac-staging.a8c-aiops.workers.dev/mcp`
+- Search/fetch compatibility: `https://mcp-server-wporg-trac-staging.a8c-aiops.workers.dev/mcp/chatgpt`
+- Health check: `https://mcp-server-wporg-trac-staging.a8c-aiops.workers.dev/health`
+
+The former staging deployment at `https://mcp-server-wporg-trac-staging.a8cai.workers.dev` is
+deprecated and runs older code. Its `a8cai.workers.dev` subdomain differs from the active staging
+deployment's `a8c-aiops.workers.dev` subdomain.
 
 ## Tools
 
@@ -99,6 +111,9 @@ Deployment requires a configured Cloudflare account:
 pnpm run deploy
 pnpm run deploy:production
 ```
+
+`pnpm run deploy` targets the active staging Worker. `pnpm run deploy:production` targets the
+production Worker.
 
 ## Design and safety
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Trac's public HTML, CSV, RSS, and diff endpoints.
 
 Live server:
 
-- Standard MCP: `https://mcp-server-wporg-trac-staging.a8cai.workers.dev/mcp`
-- Search/fetch compatibility: `https://mcp-server-wporg-trac-staging.a8cai.workers.dev/mcp/chatgpt`
-- Health check: `https://mcp-server-wporg-trac-staging.a8cai.workers.dev/health`
+- Standard MCP: `https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp`
+- Search/fetch compatibility: `https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp/chatgpt`
+- Health check: `https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/health`
 
 ## Tools
 
@@ -24,6 +24,15 @@ The standard `/mcp` endpoint provides:
 
 The `/mcp/chatgpt` compatibility endpoint provides `search` and `fetch`. Use a bare number for a
 ticket and an `r` prefix for a changeset: `65739` and `r58504`.
+
+`getChangeset` expects the numeric `revision` argument, not `rev`:
+
+```json
+{
+  "revision": 58504,
+  "includeDiff": false
+}
+```
 
 ### Search filters
 
@@ -52,7 +61,7 @@ bridge can use `mcp-remote`:
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://mcp-server-wporg-trac-staging.a8cai.workers.dev/mcp"
+        "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp"
       ]
     }
   }
@@ -62,6 +71,9 @@ bridge can use `mcp-remote`:
 For ChatGPT, add the compatibility endpoint as a custom app. See
 [OpenAI's current MCP help](https://help.openai.com/en/articles/12584461-developer-mode-and-full-mcp-connectors-in-chatgpt)
 because product labels and setup steps change.
+
+After changing a configured server URL, reconnect the MCP server or restart the client once. Future
+deployments to the same URL do not require a client configuration change.
 
 ## Develop
 
@@ -84,8 +96,8 @@ This runs TypeScript, Biome, Vitest, and a Cloudflare Worker dry-run build. See
 Deployment requires a configured Cloudflare account:
 
 ```bash
-pnpm deploy
-pnpm deploy:production
+pnpm run deploy
+pnpm run deploy:production
 ```
 
 ## Design and safety

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ The standard `/mcp` endpoint provides:
 | `getTimeline` | Read recent Trac activity |
 | `getTracInfo` | List components, milestones, priorities, severities, types, or statuses |
 
-The `/mcp/chatgpt` compatibility endpoint provides `search` and `fetch`. Use a bare number for a
-ticket and an `r` prefix for a changeset: `65739` and `r58504`.
-
 `getChangeset` expects the numeric `revision` argument, not `rev`:
 
 ```json
@@ -45,6 +42,9 @@ ticket and an `r` prefix for a changeset: `65739` and `r58504`.
   "includeDiff": false
 }
 ```
+
+The `/mcp/chatgpt` compatibility endpoint provides `search` and `fetch`. Use a bare number for a
+ticket and an `r` prefix for a changeset: `65739` and `r58504`.
 
 ### Search filters
 
@@ -108,12 +108,12 @@ This runs TypeScript, Biome, Vitest, and a Cloudflare Worker dry-run build. See
 Deployment requires a configured Cloudflare account:
 
 ```bash
+# Staging
 pnpm run deploy
+
+# Production
 pnpm run deploy:production
 ```
-
-`pnpm run deploy` targets the active staging Worker. `pnpm run deploy:production` targets the
-production Worker.
 
 ## Design and safety
 


### PR DESCRIPTION
## What changed

- Document the production and active staging endpoints.
- Mark the similarly named superseded staging deployment as deprecated.
- Document the `revision` argument for `getChangeset` and the one-time reconnect needed after a URL change.
- Use explicit `pnpm run` deployment commands and label each target environment.

## Why

The superseded and active staging Workers both respond, but their hostnames differ only by `a8cai.workers.dev` versus `a8c-aiops.workers.dev`. Naming both prevents users from mistaking old behavior for the current server. The bare `pnpm deploy` command also invokes pnpm’s built-in workspace deployment command instead of this project’s script.

## Testing

- `pnpm check`
- Confirmed all three production, active staging, and deprecated staging `/health` endpoints respond
- Production MCP client verification passed all 20 transport, tool, pagination, and error checks.