### PR TITLE
Expose production version metadata

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,9 @@ ENVIRONMENT = "development"
 name = "wordpress-trac-mcp-server-prod"
 vars = { ENVIRONMENT = "production" }
 
+[env.production.version_metadata]
+binding = "CF_VERSION_METADATA"
+
 [observability]
 enabled = true
 


### PR DESCRIPTION
## What changed

Declare the existing `CF_VERSION_METADATA` binding in the production Wrangler environment.

## Why

Named Wrangler environments do not inherit this binding from the top-level configuration. Production deployments therefore lacked version metadata, and the Worker landing page could not show its deployment version.

## Testing

- `pnpm check`
- `pnpm exec wrangler deploy --dry-run --env production`

The production dry run lists `env.CF_VERSION_METADATA` and emits no missing-environment warning.