### PR TITLE
Pin and validate production Worker configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "wrangler dev",
     "start": "wrangler dev",
     "build": "wrangler deploy --dry-run --env=\"\"",
+    "build:production": "wrangler deploy --dry-run --env production",
     "deploy": "wrangler deploy --env=\"\"",
     "deploy:production": "wrangler deploy --env production",
     "format": "biome format --write .",
@@ -16,7 +17,7 @@
     "type-check": "tsc --noEmit",
     "cf-typegen": "wrangler types",
     "test": "vitest run",
-    "check": "pnpm run type-check && pnpm run lint && pnpm run test && pnpm run build"
+    "check": "pnpm run type-check && pnpm run lint && pnpm run test && pnpm run build && pnpm run build:production"
   },
   "keywords": [
     "mcp",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,5 @@
 name = "mcp-server-wporg-trac-staging"
+account_id = "7788becfe3ab42863c7d5dec485567dc"
 main = "src/index.ts"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## What changed

- Pin Wrangler to the intended Cloudflare account.
- Add a production dry-run build and include it in `pnpm check`.

## Why

Without `account_id`, Wrangler can target whichever account is active for the current user. The quality gate also exercised only the default environment, so production-only configuration problems escaped validation. PR #22 fixes the current missing version-metadata binding; this follow-up makes the gate exercise both environments.

## Merge order

Merge #22 first. Then rebase this branch and rerun the gate so the production dry run is warning-free.

## Testing

- `pnpm check`
- Both default and production dry-run builds completed
- The production dry run currently surfaces the expected warning fixed by #22