### PR TITLE
Separate Dependabot major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
       interval: weekly
     groups:
       development-dependencies:
+        applies-to: version-updates
         dependency-type: development
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## What changed

- Limit grouped development dependency updates to minor and patch releases.
- Leave major updates as individual pull requests.

## Why

The existing grouped update in #14 combines five independent toolchain upgrades, including Biome, TypeScript, and Vitest majors. It fails CI because Biome 2 needs a configuration migration, and the combined scope makes review and rollback harder.

Keeping routine minor and patch updates grouped preserves low-noise maintenance while making major migrations individually reviewable.

## Validation

- Parsed `.github/dependabot.yml` as YAML.
- Ran `pnpm check`, including type checking, formatting, tests, and development and production build dry runs.
