### PR TITLE
Normalize empty linked PR records

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,8 +28,10 @@ Start the Worker with `pnpm dev`, then use harmless public ticket and changeset 
    - Search a keyword and a structured filter.
    - Read ticket `65739` with and without comments.
    - Read ticket `65808` and confirm its linked pull request data is present.
-   - Read ticket `65793` and confirm attachments are separate from comments.
-   - Read ticket `62358` and confirm changesets are separate from comments.
+   - Read ticket `65793`; confirm linked pull request data remains available with no reviews and
+     attachments are separate from comments.
+   - Read ticket `62358`; confirm linked pull request data remains available with no checks and
+     changesets are separate from comments.
    - Read changeset `58504` with and without its diff.
    - Read one day of timeline activity.
    - List components and milestones.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,64 @@ function mcpRequest(body: unknown, path = '/mcp') {
   );
 }
 
+function linkedPullRequestFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 12833,
+    repo: 'WordPress/wordpress-develop',
+    state: 'closed',
+    title: 'REST API: Always register the media creation arguments',
+    user: {
+      name: 'contributor',
+      url: 'https://github.com/contributor',
+    },
+    created_at: '2026-08-04T07:18:35Z',
+    updated_at: '2026-08-05T06:41:21Z',
+    closed_at: '2026-08-05T06:41:21Z',
+    changes: {
+      additions: 234,
+      deletions: 45,
+      patch_url: 'https://github.com/WordPress/wordpress-develop/pull/12833.diff',
+      html_url: 'https://github.com/WordPress/wordpress-develop/pull/12833',
+    },
+    touches_tests: true,
+    check_runs: { 'GitHub Actions': 'success' },
+    reviews: { APPROVED: ['reviewer'] },
+    mergeable_state: 'blocked',
+    body: 'Pull request description',
+    html_url: 'https://github.com/WordPress/wordpress-develop/pull/12833',
+    ...overrides,
+  };
+}
+
+async function getTicketWithLinkedPullRequest(pullRequest = linkedPullRequestFixture()) {
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+    .mockResolvedValueOnce(
+      new Response(
+        '<?xml version="1.0"?><rss><channel><description>Ticket description</description></channel></rss>'
+      )
+    )
+    .mockResolvedValueOnce(Response.json([pullRequest]));
+  vi.stubGlobal('fetch', fetchMock);
+
+  const response = await mcpRequest({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: {
+      name: 'getTicket',
+      arguments: { id: 65808, includeComments: true, commentLimit: 10 },
+    },
+  });
+  const body = (await response.json()) as RpcBody;
+
+  return {
+    fetchMock,
+    result: JSON.parse(body.result.content.at(0)?.text ?? '{}'),
+  };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
@@ -246,56 +304,7 @@ describe('MCP transport', () => {
   });
 
   it('includes linked pull request status, checks, reviews, and changes with a ticket', async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
-      .mockResolvedValueOnce(
-        new Response(
-          '<?xml version="1.0"?><rss><channel><description>Ticket description</description></channel></rss>'
-        )
-      )
-      .mockResolvedValueOnce(
-        Response.json([
-          {
-            number: 12833,
-            repo: 'WordPress/wordpress-develop',
-            state: 'closed',
-            title: 'REST API: Always register the media creation arguments',
-            user: {
-              name: 'contributor',
-              url: 'https://github.com/contributor',
-            },
-            created_at: '2026-08-04T07:18:35Z',
-            updated_at: '2026-08-05T06:41:21Z',
-            closed_at: '2026-08-05T06:41:21Z',
-            changes: {
-              additions: 234,
-              deletions: 45,
-              patch_url: 'https://github.com/WordPress/wordpress-develop/pull/12833.diff',
-              html_url: 'https://github.com/WordPress/wordpress-develop/pull/12833',
-            },
-            touches_tests: true,
-            check_runs: { 'GitHub Actions': 'success' },
-            reviews: { APPROVED: ['reviewer'] },
-            mergeable_state: 'blocked',
-            body: 'Pull request description',
-            html_url: 'https://github.com/WordPress/wordpress-develop/pull/12833',
-          },
-        ])
-      );
-    vi.stubGlobal('fetch', fetchMock);
-
-    const response = await mcpRequest({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'tools/call',
-      params: {
-        name: 'getTicket',
-        arguments: { id: 65808, includeComments: true, commentLimit: 10 },
-      },
-    });
-    const body = (await response.json()) as RpcBody;
-    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+    const { fetchMock, result } = await getTicketWithLinkedPullRequest();
 
     expect(fetchMock.mock.calls[2]?.[0]?.toString()).toBe(
       'https://api.wordpress.org/dotorg/trac/pr/?trac=core&ticket=65808'
@@ -319,11 +328,46 @@ describe('MCP transport', () => {
   });
 
   it.each([
+    {
+      label: 'check list',
+      overrides: { check_runs: [] },
+      expectedCheckRuns: {},
+      expectedReviews: { APPROVED: ['reviewer'] },
+      expectedText: 'CI: No check results',
+    },
+    {
+      label: 'review list',
+      overrides: { reviews: [] },
+      expectedCheckRuns: { 'GitHub Actions': 'success' },
+      expectedReviews: {},
+      expectedText: 'Reviews: No reviews',
+    },
+  ])(
+    'normalizes an empty linked pull request $label',
+    async ({ overrides, expectedCheckRuns, expectedReviews, expectedText }) => {
+      const { result } = await getTicketWithLinkedPullRequest(linkedPullRequestFixture(overrides));
+
+      expect(result.metadata.linkedPullRequests).toEqual([
+        expect.objectContaining({
+          checkRuns: expectedCheckRuns,
+          reviews: expectedReviews,
+        }),
+      ]);
+      expect(result.metadata.linkedPullRequestsUnavailable).toBe(false);
+      expect(result.text).toContain(expectedText);
+    }
+  );
+
+  it.each([
     [
       'an HTTP error',
       () => new Response('Unavailable', { status: 503, statusText: 'Unavailable' }),
     ],
     ['an unexpected response shape', () => Response.json([{ unexpected: 'shape' }])],
+    [
+      'a non-empty list for a record field',
+      () => Response.json([linkedPullRequestFixture({ reviews: ['unexpected'] })]),
+    ],
   ])('keeps the ticket available when linked pull requests return %s', async (_label, response) => {
     vi.stubGlobal(
       'fetch',

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,11 @@ const ChatGptSearchArgsSchema = z.object({
 const ChatGptFetchArgsSchema = z.object({
   id: z.string().regex(/^(?:r\d+|\d+)$/, 'Use a ticket number or an r-prefixed changeset'),
 });
+
+function normalizeEmptyRecord(value: unknown) {
+  return Array.isArray(value) && value.length === 0 ? {} : value;
+}
+
 const LinkedPullRequestSchema = z.object({
   number: z.number().int().positive(),
   repo: z.string(),
@@ -64,8 +69,8 @@ const LinkedPullRequestSchema = z.object({
     html_url: z.string().url(),
   }),
   touches_tests: z.boolean(),
-  check_runs: z.record(z.string()),
-  reviews: z.record(z.array(z.string())),
+  check_runs: z.preprocess(normalizeEmptyRecord, z.record(z.string())),
+  reviews: z.preprocess(normalizeEmptyRecord, z.record(z.array(z.string()))),
   mergeable_state: z.string(),
   body: z.string().nullable(),
   html_url: z.string().url(),


### PR DESCRIPTION
## What changed

- Normalize empty `check_runs` and `reviews` arrays to empty records before strict linked-PR validation.
- Continue rejecting non-empty arrays and other malformed response shapes.
- Add regression coverage and targeted live-smoke instructions.

## Why

The official linked-PR endpoint sometimes serializes empty maps as arrays. Ticket 65793 currently returns `reviews: []`, while ticket 62358 returns `check_runs: []`. Both are valid empty states, but the strict schema rejects them and marks all linked-PR enrichment unavailable.

## Validation

- `pnpm check`: type checking, Biome, 25 Vitest tests, and development and production Worker dry runs.
- Local MCP smoke tests against tickets 65793 and 62358 confirmed linked-PR enrichment remains available and exposes empty records.
