### PR TITLE
Add MCP registry metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.WordPress/trac-mcp",
+  "title": "WordPress Core Trac",
+  "description": "Read-only Model Context Protocol server for WordPress Core Trac",
+  "version": "1.0.0",
+  "websiteUrl": "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/",
+  "repository": {
+    "url": "https://github.com/WordPress/trac-mcp",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Add a canonical `server.json` using the official MCP Registry schema.
- Identify the server as `io.github.WordPress/trac-mcp`.
- Advertise only the production Streamable HTTP endpoint.

## Why

This provides a maintainer-controlled metadata source for official registry publication and downstream directory updates. It is the first implementation step in #16; publication and external listing updates remain separate tasks.

## Validation

- The official registry `/v0.1/validate` endpoint returned `valid: true` with no issues.
- `pnpm check` passed type checking, Biome, 25 Vitest tests, and development and production Worker dry runs.
