### PR TITLE
Add Glama ownership metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["lancewillett"]
+}


### PR DESCRIPTION
## What changed

- Added `glama.json` with the Glama schema.
- Registered `lancewillett` as a maintainer.

## Why

Glama requires repository metadata to claim listings for organization-owned GitHub repositories. The existing listing still points to the repository's former owner and contains outdated documentation and capability claims.

After this merges, the maintainer can run Glama's claim flow again and correct the listing.

## Checks

- `pnpm check`

Part of #16.
