### PR TITLE
Document local browser development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ pnpm dev
 pnpm check
 ```
 
+For a browser-visible local preview, keep `pnpm dev` running and open `http://localhost:8787/`. Check `http://localhost:8787/health` for `OK`. See `docs/local-development.md` for the full workflow and troubleshooting.
+
 `pnpm check` is the required pre-PR gate. It runs TypeScript, Biome, Vitest, and a Cloudflare Worker dry-run build for both environments. CI runs the same command, so run it locally first rather than using CI as the first check.
 
 Green CI does not mean the feature works: every automated test mocks Trac. Follow `docs/testing.md` when a change affects live Trac parsing or MCP transport, and see `tests/AGENTS.md` for how the automated and manual layers divide the work.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ pnpm install
 pnpm dev
 ```
 
+Open `http://localhost:8787/` to view the local landing page. See
+[docs/local-development.md](docs/local-development.md) for the full browser-preview workflow and
+troubleshooting.
+
 Run the complete local quality gate:
 
 ```bash

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,7 +6,7 @@
 - `smoke-test.md` is that manual checklist as paste-ready commands with expected results.
 - `local-development.md` explains how to run the Worker locally and verify its browser-visible routes.
 
-The two are one document split by audience. `testing.md` explains the shape, `smoke-test.md` is what you actually run. Change one and check the other still agrees.
+`testing.md` and `smoke-test.md` are one document split by audience. `testing.md` explains the shape, `smoke-test.md` is what you actually run. Change one and check the other still agrees.
 
 ## Verify before you document
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,6 +4,7 @@
 
 - `testing.md` is the canonical description of how this repository is tested: the automated gate CI runs, the manual smoke test, and what to do before a deployment.
 - `smoke-test.md` is that manual checklist as paste-ready commands with expected results.
+- `local-development.md` explains how to run the Worker locally and verify its browser-visible routes.
 
 The two are one document split by audience. `testing.md` explains the shape, `smoke-test.md` is what you actually run. Change one and check the other still agrees.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -7,10 +7,10 @@ Use Wrangler to run the Worker on your computer. Local development does not requ
 - Node.js 22 or later.
 - pnpm 10.
 
-Install the locked dependencies:
+Install the dependencies:
 
 ```bash
-pnpm install --frozen-lockfile
+pnpm install
 ```
 
 ## Start the Worker
@@ -31,7 +31,7 @@ Keep that terminal open. Wrangler will build the Worker, watch the source files,
 
 Press `b` in the Wrangler terminal, or open [http://localhost:8787/](http://localhost:8787/) yourself. The root route is a browser-visible landing page that lists the MCP tools and shows local connection examples.
 
-After editing `src/index.ts`, wait for Wrangler to rebuild and refresh the page. The browser examples should continue to use `http://localhost:8787`; they do not change a deployed environment.
+After editing `src/index.ts`, wait for Wrangler to rebuild and refresh the page. The browser examples should continue to use the origin you started on; they do not change a deployed environment.
 
 Open [http://localhost:8787/health](http://localhost:8787/health) in another tab. It should show:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,84 @@
+# Local development
+
+Use Wrangler to run the Worker on your computer. Local development does not require a Cloudflare account or credentials.
+
+## Requirements
+
+- Node.js 22 or later.
+- pnpm 10.
+
+Install the locked dependencies:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+## Start the Worker
+
+Run:
+
+```bash
+pnpm dev
+```
+
+Keep that terminal open. Wrangler will build the Worker, watch the source files, and print:
+
+```text
+[wrangler:info] Ready on http://localhost:8787
+```
+
+## Open the browser test page
+
+Press `b` in the Wrangler terminal, or open [http://localhost:8787/](http://localhost:8787/) yourself. The root route is a browser-visible landing page that lists the MCP tools and shows local connection examples.
+
+After editing `src/index.ts`, wait for Wrangler to rebuild and refresh the page. The browser examples should continue to use `http://localhost:8787`; they do not change a deployed environment.
+
+Open [http://localhost:8787/health](http://localhost:8787/health) in another tab. It should show:
+
+```text
+OK
+```
+
+You can run the same health check from another terminal:
+
+```bash
+curl --fail http://localhost:8787/health
+```
+
+Press `Ctrl+C` in the Wrangler terminal to stop the server.
+
+## Troubleshooting
+
+### The browser cannot connect
+
+Confirm the Wrangler terminal is still open and shows the `Ready` message. Restart `pnpm dev` if the process stopped.
+
+### Port 8787 is already in use
+
+Choose another port:
+
+```bash
+pnpm exec wrangler dev --port 8788
+```
+
+Then open `http://localhost:8788/` and `http://localhost:8788/health`.
+
+### The runtime or dependencies do not match
+
+Check the installed versions and restore the locked dependencies:
+
+```bash
+node --version
+pnpm --version
+pnpm install --frozen-lockfile
+```
+
+## Before opening a pull request
+
+Run the complete local gate:
+
+```bash
+pnpm check
+```
+
+If your change affects MCP transport or live Trac parsing, also follow the [manual smoke test](smoke-test.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ Tests mock Trac responses. They should not depend on Trac availability or mutabl
 
 ## Manual smoke test
 
-Start the Worker with `pnpm dev`, then use harmless public ticket and changeset IDs. See [smoke-test.md](smoke-test.md) for the same list as runnable commands with expected results.
+Start the Worker by following [local-development.md](local-development.md), then use harmless public ticket and changeset IDs. See [smoke-test.md](smoke-test.md) for the same list as runnable commands with expected results.
 
 1. Confirm `/health` returns `200 OK` and `/` renders the landing page.
 2. Send `OPTIONS /mcp`; expect `204` and CORS headers.


### PR DESCRIPTION
## Summary

- add a local development guide for starting Wrangler and opening the landing page in a browser
- document the health check, shutdown flow, and common startup problems
- link the guide from the README, testing docs, and contributor instructions

## Why

The repository documented `pnpm dev`, but it did not explain how to reach the browser-visible page or recover from a stopped server or occupied port. This gives contributors one tested path from dependency installation to local verification.

## Verification

- `pnpm check`
- started `pnpm dev`; verified the landing page in a browser and `/health` returned `OK`
- started `pnpm exec wrangler dev --port 8788`; verified the landing page and health route on the alternate port
- ran `pnpm install --frozen-lockfile` with the current lockfile