### PR TITLE
Add machine-readable error codes to tool error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ ticket and an `r` prefix for a changeset: `65739` and `r58504`.
 It also accepts `status`, `component`, `milestone`, and `resolution` as separate arguments. A
 separate argument overrides the same field in `query`. Results include pagination metadata.
 
+### Tool errors
+
+A failed tool call returns an MCP result with `isError: true`. Its JSON payload carries a
+machine-readable `code` alongside the human-readable `error` message. `not_found` errors also name
+the `resource` and `id` that were requested:
+
+```json
+{
+  "code": "not_found",
+  "error": "Ticket 99999999 not found",
+  "resource": "ticket",
+  "id": 99999999
+}
+```
+
+| `code` | Meaning |
+| --- | --- |
+| `not_found` | The requested ticket or changeset does not exist |
+| `invalid_argument` | An argument passed schema validation but cannot be used, such as an unsupported search filter field |
+| `rate_limited` | Trac throttled the request and bounded retries did not clear it |
+| `upstream_error` | Trac or a supporting service failed or returned unexpected content |
+
+Codes are stable API surface: branch on `code`, never on `error` wording. An existing code keeps
+its meaning and is only removed or renamed with a major version bump, while messages can change
+freely. New codes may be added over time, so treat an unrecognized code as `upstream_error`.
+
+Arguments that fail schema validation are rejected earlier with a JSON-RPC `-32602` invalid-params
+error and do not produce a tool error result.
+
 ## Connect
 
 Remote-capable MCP clients can connect directly to the standard endpoint. Clients that need a local

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -74,6 +74,7 @@ Use these public tickets only. Each one is here because it covers a distinct par
 | `65793` | Linked PR with no reviews; attachments kept separate from comments |
 | `62358` | Linked PR with no checks; changesets kept separate from comments |
 | `r58504` | Changeset, with and without its diff |
+| `99999999` | Nonexistent ticket and revision; the `not_found` tool error path |
 
 ```bash
 call /mcp searchTickets '{"query":"editor","limit":2}'
@@ -131,6 +132,16 @@ call /mcp getTracInfo '{}'
 ```
 
 Every one of these returns a JSON-RPC error rather than a success envelope or a crash. Bad arguments come back as `-32602` invalid params with the failing field named. A malformed request that returns `200` with empty content is a bug.
+
+Failures inside a tool return a tool result with `isError: true` and a machine-readable `code` next to the prose `error` message:
+
+```bash
+call /mcp getTicket '{"id":99999999}'
+call /mcp getChangeset '{"revision":99999999,"includeDiff":false}'
+call /mcp searchTickets '{"query":"bogusfield~=value"}'
+```
+
+The missing ticket and changeset each return `"code": "not_found"` with `resource` and `id` naming what was requested, for example `{"code": "not_found", "error": "Ticket 99999999 not found", "resource": "ticket", "id": 99999999}`. The unsupported filter field returns `"code": "invalid_argument"`. The full code set and its stability guarantee are documented in the README under "Tool errors".
 
 ## Reading a failure
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,6 +36,7 @@ Start the Worker by following [local-development.md](local-development.md), then
 5. Check search page 1 and a page beyond the final result; the latter should return an empty page.
 6. Initialize `/mcp/chatgpt`, then search a keyword, ticket `65739`, and changeset `r58504`.
 7. Send invalid arguments and confirm the response is a JSON-RPC invalid-params error.
+8. Request ticket `99999999` and changeset `99999999`; confirm each returns a tool error whose payload carries `"code": "not_found"` with the resource and ID named. Search with an unsupported filter field and confirm `"code": "invalid_argument"`.
 
 Do not paste private ticket data or credentials into fixtures. If live checks fail, distinguish a Trac response change from Worker behavior before changing a parser.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -278,9 +278,11 @@ describe('MCP transport', () => {
       },
     });
     const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
 
     expect(body.result.isError).toBe(true);
-    expect(body.result.content.at(0)?.text).toContain('Forbidden');
+    expect(result.code).toBe('upstream_error');
+    expect(result.error).toContain('Forbidden');
   });
 
   it('requests timeline activity ending today across ticket and repository events', async () => {
@@ -481,6 +483,127 @@ describe('MCP transport', () => {
     const body = (await response.json()) as RpcBody;
 
     expect(body.error.code).toBe(-32602);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a not_found code for a missing ticket', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n'))
+        .mockResolvedValueOnce(new Response('Not Found', { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTicket', arguments: { id: 99999999 } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      code: 'not_found',
+      error: 'Ticket 99999999 not found',
+      resource: 'ticket',
+      id: 99999999,
+    });
+  });
+
+  it('returns a not_found code for a missing changeset', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response('Not Found', { status: 404, statusText: 'Not Found' }))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getChangeset', arguments: { revision: 99999999, includeDiff: false } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      code: 'not_found',
+      error: 'Changeset 99999999 not found',
+      resource: 'changeset',
+      id: 99999999,
+    });
+  });
+
+  it('reports an upstream error, not a missing ticket, when the history fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+        .mockResolvedValueOnce(new Response('Forbidden', { status: 403, statusText: 'Forbidden' }))
+        .mockResolvedValueOnce(Response.json([]))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTicket', arguments: { id: 65808 } },
+    });
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(body.result.isError).toBe(true);
+    expect(result.code).toBe('upstream_error');
+    expect(result.error).toBe('HTTP 403: Forbidden');
+  });
+
+  it('returns a rate_limited code when Trac throttling outlasts the retries', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response('Too Many Requests', { status: 429, statusText: 'Too Many Requests' })
+        )
+    );
+
+    const responsePromise = mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getChangeset', arguments: { revision: 58504, includeDiff: false } },
+    });
+    await vi.runAllTimersAsync();
+    const body = (await (await responsePromise).json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(body.result.isError).toBe(true);
+    expect(result.code).toBe('rate_limited');
+    expect(result.error).toBe('HTTP 429: Too Many Requests');
+  });
+
+  it('returns an invalid_argument code for an unsupported search filter', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'searchTickets', arguments: { query: 'bogusfield~=value' } },
+    });
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(body.result.isError).toBe(true);
+    expect(result.code).toBe('invalid_argument');
+    expect(result.error).toBe('Unsupported ticket filter: bogusfield');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -538,6 +538,35 @@ describe('MCP transport', () => {
     });
   });
 
+  it('reports an upstream error when ticket CSV data is absent but history exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n'))
+        .mockResolvedValueOnce(
+          new Response(
+            '<?xml version="1.0"?><rss><channel><description>Ticket description</description></channel></rss>'
+          )
+        )
+        .mockResolvedValueOnce(Response.json([]))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTicket', arguments: { id: 99999999 } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      code: 'upstream_error',
+      error: 'Trac returned inconsistent data for ticket 99999999',
+    });
+  });
+
   it('reports an upstream error, not a missing ticket, when the history fetch fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -567,6 +567,31 @@ describe('MCP transport', () => {
     });
   });
 
+  it('reports an upstream error when ticket CSV data exists but history is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+        .mockResolvedValueOnce(new Response('Not Found', { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(Response.json([]))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTicket', arguments: { id: 65808 } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      code: 'upstream_error',
+      error: 'Trac returned inconsistent data for ticket 65808',
+    });
+  });
+
   it('reports an upstream error, not a missing ticket, when the history fetch fails', async () => {
     vi.stubGlobal(
       'fetch',
@@ -636,30 +661,107 @@ describe('MCP transport', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it.each(['99999999', 'r99999999'])(
-    'returns no search matches when direct lookup %s does not exist',
-    async (query) => {
-      vi.stubGlobal(
-        'fetch',
-        vi
-          .fn<typeof fetch>()
-          .mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' }))
-      );
+  it('returns no search matches when an exact ticket does not exist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n'))
+        .mockResolvedValueOnce(new Response('', { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(Response.json([]))
+    );
 
-      const response = await mcpRequest(
-        {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'tools/call',
-          params: { name: 'search', arguments: { query } },
-        },
-        '/mcp/chatgpt'
-      );
-      const body = (await response.json()) as RpcBody;
-      const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'search', arguments: { query: '99999999' } },
+      },
+      '/mcp/chatgpt'
+    );
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
 
-      expect(body.result.isError).toBeUndefined();
-      expect(result).toEqual({ results: [], query, totalFound: 0 });
-    }
-  );
+    expect(body.result.isError).toBeUndefined();
+    expect(result).toEqual({ results: [], query: '99999999', totalFound: 0 });
+  });
+
+  it('returns no search matches when an exact changeset does not exist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' }))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'search', arguments: { query: 'r99999999' } },
+      },
+      '/mcp/chatgpt'
+    );
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(body.result.isError).toBeUndefined();
+    expect(result).toEqual({ results: [], query: 'r99999999', totalFound: 0 });
+  });
+
+  it('propagates an upstream error from an exact ticket search', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+        .mockResolvedValueOnce(new Response('Forbidden', { status: 403, statusText: 'Forbidden' }))
+        .mockResolvedValueOnce(Response.json([]))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'search', arguments: { query: '65808' } },
+      },
+      '/mcp/chatgpt'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      code: 'upstream_error',
+      error: 'HTTP 403: Forbidden',
+    });
+  });
+
+  it('propagates an upstream error from an exact changeset search', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response('Forbidden', { status: 403, statusText: 'Forbidden' }))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'search', arguments: { query: 'r58504' } },
+      },
+      '/mcp/chatgpt'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      code: 'upstream_error',
+      error: 'HTTP 403: Forbidden',
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,28 @@ const LinkedPullRequestSchema = z.object({
 
 class UnknownToolError extends Error {}
 
+// Stable, machine-readable tool error codes. These are API surface documented in the README:
+// consumers branch on them, so codes only change with a version bump. Messages can change freely.
+type ToolErrorCode = 'not_found' | 'invalid_argument' | 'rate_limited' | 'upstream_error';
+
+class ToolError extends Error {
+  readonly code: ToolErrorCode;
+  readonly details: { resource?: 'ticket' | 'changeset'; id?: number };
+
+  constructor(code: ToolErrorCode, message: string, details: ToolError['details'] = {}) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function upstreamHttpError(
+  response: Response,
+  message = `HTTP ${response.status}: ${response.statusText}`
+): ToolError {
+  return new ToolError(response.status === 429 ? 'rate_limited' : 'upstream_error', message);
+}
+
 const TRAC_USER_AGENT = 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)';
 const TRAC_ORIGIN = 'https://core.trac.wordpress.org';
 const TRAC_RETRY_DELAYS_MS = [2000, 4000, 8000] as const;
@@ -456,7 +478,7 @@ function addColumns(url: URL, columns: readonly string[]): void {
 export function parseTicketFilter(expression: string): [string, string] {
   const match = expression.match(/^([a-z][a-z0-9_]*)(~=|=)(.+)$/i);
   if (!match?.[1] || !match[2] || !match[3]) {
-    throw new Error(`Invalid ticket filter expression: ${expression}`);
+    throw new ToolError('invalid_argument', `Invalid ticket filter expression: ${expression}`);
   }
 
   const field = match[1].toLowerCase();
@@ -464,7 +486,7 @@ export function parseTicketFilter(expression: string): [string, string] {
     !TICKET_COLUMNS.includes(field as (typeof TICKET_COLUMNS)[number]) &&
     field !== 'description'
   ) {
-    throw new Error(`Unsupported ticket filter: ${field}`);
+    throw new ToolError('invalid_argument', `Unsupported ticket filter: ${field}`);
   }
 
   return [field, match[2] === '~=' ? `~${match[3]}` : match[3]];
@@ -503,12 +525,12 @@ async function fetchCsvRecords(url: URL): Promise<TracRecord[]> {
   });
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    throw upstreamHttpError(response);
   }
 
   const csvData = await response.text();
   if (/<!doctype html|<html/i.test(csvData)) {
-    throw new Error('Trac returned HTML instead of CSV');
+    throw new ToolError('upstream_error', 'Trac returned HTML instead of CSV');
   }
 
   return parseCsvRecords(csvData);
@@ -627,7 +649,7 @@ export async function searchTracTickets(
   const totalHtml = await totalResponse.text();
   const totalMatch = totalHtml.match(/<span class="numrows">\s*\(([\d,]+)\s+match(?:es)?\)/i);
   if (!totalMatch?.[1]) {
-    throw new Error('Trac did not return the total ticket count');
+    throw new ToolError('upstream_error', 'Trac did not return the total ticket count');
   }
 
   const totalFound = Number.parseInt(totalMatch[1].replace(/,/g, ''), 10);
@@ -658,8 +680,14 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   ]);
 
   const record = records.find((candidate) => Number.parseInt(candidate.id ?? '', 10) === ticketId);
-  if (!record || !rssResponse.ok) {
-    throw new Error(`Ticket ${ticketId} not found`);
+  if (!record || rssResponse.status === 404) {
+    throw new ToolError('not_found', `Ticket ${ticketId} not found`, {
+      resource: 'ticket',
+      id: ticketId,
+    });
+  }
+  if (!rssResponse.ok) {
+    throw upstreamHttpError(rssResponse);
   }
 
   const rssText = await rssResponse.text();
@@ -782,6 +810,16 @@ ${ticket.description}${linkedPullRequestsText}${attachmentsText}${changesetsText
   };
 }
 
+function changesetFetchError(revision: number, response: Response): ToolError {
+  if (response.status === 404) {
+    return new ToolError('not_found', `Changeset ${revision} not found`, {
+      resource: 'changeset',
+      id: revision,
+    });
+  }
+  return upstreamHttpError(response);
+}
+
 async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit = 2000) {
   const changesetUrl = `https://core.trac.wordpress.org/changeset/${revision}`;
   const response = await fetchTrac(changesetUrl, {
@@ -789,7 +827,7 @@ async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit 
   });
 
   if (!response.ok) {
-    throw new Error(`Changeset ${revision} not found`);
+    throw changesetFetchError(revision, response);
   }
 
   const html = await response.text();
@@ -864,7 +902,7 @@ async function fetchTracFieldOptions(field: 'component' | 'severity'): Promise<s
   });
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    throw upstreamHttpError(response);
   }
 
   const html = await response.text();
@@ -872,7 +910,7 @@ async function fetchTracFieldOptions(field: 'component' | 'severity'): Promise<s
     new RegExp(`<select\\s+name="0_${field}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i')
   )?.[1];
   if (!select) {
-    throw new Error(`Trac did not return ${field} options`);
+    throw new ToolError('upstream_error', `Trac did not return ${field} options`);
   }
 
   return Array.from(select.matchAll(/<option[^>]*value="([^"]+)"[^>]*>/gi), (match) =>
@@ -925,7 +963,7 @@ async function fetchTimeline(days: number, limit: number) {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
   if (!response.ok) {
-    throw new Error(`Failed to fetch timeline: ${response.statusText}`);
+    throw upstreamHttpError(response, `Failed to fetch timeline: ${response.statusText}`);
   }
 
   return parseRssItems(await response.text()).map((item, index) => ({
@@ -958,6 +996,16 @@ function toolResult(id: JsonRpcRequest['id'], result: unknown, isError = false) 
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function toolErrorResult(id: JsonRpcRequest['id'], error: unknown) {
+  const toolError =
+    error instanceof ToolError ? error : new ToolError('upstream_error', errorMessage(error));
+  return toolResult(
+    id,
+    { code: toolError.code, error: toolError.message, ...toolError.details },
+    true
+  );
 }
 
 async function executeStandardTool(name: string, input: unknown): Promise<unknown> {
@@ -1219,7 +1267,7 @@ export async function handleMcpRequest(request: JsonRpcRequest) {
         if (error instanceof UnknownToolError || error instanceof z.ZodError) {
           return jsonRpcError(id, -32602, errorMessage(error));
         }
-        return toolResult(id, { error: errorMessage(error) }, true);
+        return toolErrorResult(id, error);
       }
     }
 
@@ -1314,7 +1362,7 @@ Query Types:
         if (error instanceof UnknownToolError || error instanceof z.ZodError) {
           return jsonRpcError(id, -32602, errorMessage(error));
         }
-        return toolResult(id, { error: errorMessage(error) }, true);
+        return toolErrorResult(id, error);
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,6 +682,12 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
 
   const record = records.find((candidate) => Number.parseInt(candidate.id ?? '', 10) === ticketId);
   if (rssResponse.status === 404) {
+    if (record) {
+      throw new ToolError(
+        'upstream_error',
+        `Trac returned inconsistent data for ticket ${ticketId}`
+      );
+    }
     throw new ToolError('not_found', `Ticket ${ticketId} not found`, {
       resource: 'ticket',
       id: ticketId,
@@ -1412,7 +1418,10 @@ async function runChatGptSearch(query: string) {
         false
       );
       return { results: [ticket], query, totalFound: 1 };
-    } catch {
+    } catch (error) {
+      if (!(error instanceof ToolError) || error.code !== 'not_found') {
+        throw error;
+      }
       return { results: [], query, totalFound: 0 };
     }
   }
@@ -1420,7 +1429,10 @@ async function runChatGptSearch(query: string) {
     try {
       const changeset = await getChangesetForChatGPT(Number.parseInt(trimmed.slice(1), 10), false);
       return { results: [changeset], query, totalFound: 1 };
-    } catch {
+    } catch (error) {
+      if (!(error instanceof ToolError) || error.code !== 'not_found') {
+        throw error;
+      }
       return { results: [], query, totalFound: 0 };
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ class ToolError extends Error {
 
   constructor(code: ToolErrorCode, message: string, details: ToolError['details'] = {}) {
     super(message);
+    this.name = 'ToolError';
     this.code = code;
     this.details = details;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -681,7 +681,7 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   ]);
 
   const record = records.find((candidate) => Number.parseInt(candidate.id ?? '', 10) === ticketId);
-  if (!record || rssResponse.status === 404) {
+  if (rssResponse.status === 404) {
     throw new ToolError('not_found', `Ticket ${ticketId} not found`, {
       resource: 'ticket',
       id: ticketId,
@@ -689,6 +689,9 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   }
   if (!rssResponse.ok) {
     throw upstreamHttpError(rssResponse);
+  }
+  if (!record) {
+    throw new ToolError('upstream_error', `Trac returned inconsistent data for ticket ${ticketId}`);
   }
 
   const rssText = await rssResponse.text();


### PR DESCRIPTION
Fixes #43

Tool error payloads now carry a stable `code` field next to the prose `error` message, so consumers can branch on the failure kind instead of pattern-matching English text:

```json
{
  "code": "not_found",
  "error": "Ticket 99999999 not found",
  "resource": "ticket",
  "id": 99999999
}
```

## What changed

- A `ToolError` class carries a stable `code` (`not_found`, `invalid_argument`, `rate_limited`, `upstream_error`) plus optional `resource`/`id` details. Every tool error result includes a code; unclassified failures fall back to `upstream_error`. Existing `error` message wording is unchanged.
- **Classification is status-aware**, which also fixes a latent misreport: previously `getTicket`/`getChangeset` reported "not found" for *any* upstream failure. Now `not_found` is emitted only when the ticket-history RSS request returns 404; an empty ticket CSV paired with successful history RSS is `upstream_error`, a 429 that outlasts retries reports `rate_limited`, and other failures report `upstream_error` with the HTTP status — the "missing ticket vs. broken service" distinction the issue asks for.
- `invalid_argument` covers filter-expression errors in `searchTickets` (e.g. an unsupported filter field). Arguments failing schema validation still return JSON-RPC `-32602` before any upstream request, unchanged and now documented as intentional.
- README gains a "Tool errors" section documenting the code set and its stability guarantee alongside the tool docs: branch on `code`, never on `error` wording; codes only change with a version bump; treat unrecognized codes as `upstream_error`.
- `docs/testing.md` and `docs/smoke-test.md` gain the error-path checks.

## Acceptance criteria

- [x] Every tool error result includes a `code` from a documented, enumerated set.
- [x] `not_found` is emitted for a missing ticket (`getTicket`) and a missing changeset (`getChangeset`).
- [x] The code set and its stability guarantee are documented alongside the tool schemas.
- [x] The `error` message field is retained with its current wording.

## Testing

- `pnpm check` passes (TypeScript, Biome, 32 Vitest tests, both Worker dry-run builds).
- Six new tests: missing ticket, missing changeset, empty ticket CSV paired with successful history RSS (asserts `upstream_error`), ticket-exists-but-history-fetch-fails (asserts `upstream_error`, not `not_found`), persistent 429 → `rate_limited`, unsupported filter → `invalid_argument`.
- Live smoke test against real Trac via `pnpm dev`: every command added to `smoke-test.md` was run against the local server, confirming Trac 404s missing changesets and returns an empty CSV for missing tickets, and that happy paths on both `/mcp` and `/mcp/chatgpt` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)