### PR TITLE
Rename the default branch to trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: read

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -136,9 +136,9 @@ Every one of these returns a JSON-RPC error rather than a success envelope or a 
 
 Work through these in order before changing a parser.
 
-1. **Does the same check pass locally?** Run the list against `pnpm dev` on current `main`. If local passes and the deployment fails, the deployment is behind.
+1. **Does the same check pass locally?** Run the list against `pnpm dev` on current `trunk`. If local passes and the deployment fails, the deployment is behind.
 
-   To confirm that, compare behavior rather than version strings. Run `tools/list` against both and diff the advertised arguments: a deployment missing a field that `main` advertises is stale. The version on the landing page is Cloudflare's opaque Worker version ID, not a git commit, so it cannot be matched against a branch. Its deployment timestamp is the useful part, and the Cloudflare dashboard's deployment history maps that ID to what shipped.
+   To confirm that, compare behavior rather than version strings. Run `tools/list` against both and diff the advertised arguments: a deployment missing a field that `trunk` advertises is stale. The version on the landing page is Cloudflare's opaque Worker version ID, not a git commit, so it cannot be matched against a branch. Its deployment timestamp is the useful part, and the Cloudflare dashboard's deployment history maps that ID to what shipped.
 2. **Did Trac change, or did we?** Fetch the upstream URL by hand and look at the markup. Trac changing its HTML and our parser regressing produce the same symptom.
 3. **Is it the fixture?** These are real public tickets and their content can move. A ticket that gains its first attachment can turn a passing check into a failing one. Confirm the ticket still covers the case in the table above before treating it as a regression.
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,12 +6,12 @@ Two layers, and they catch different failures.
 
 | Layer | Command | Runs in CI | Catches |
 | --- | --- | --- | --- |
-| Automated | `pnpm check` | Yes, on every PR and push to `main` | Type errors, lint and format drift, parser and protocol regressions against mocked responses, a broken Worker build in either environment |
+| Automated | `pnpm check` | Yes, on every PR and push to `trunk` | Type errors, lint and format drift, parser and protocol regressions against mocked responses, a broken Worker build in either environment |
 | Manual smoke test | `docs/smoke-test.md` | No | A stale deployment, upstream Trac markup changes, transport behavior against a real server |
 
 CI (`.github/workflows/ci.yml`) runs the same project check and nothing else, so run it locally before pushing rather than using CI as the first check. A local pass is a good signal, not a guarantee. CI installs from a frozen lockfile on Linux with Node 22 and depends on GitHub services. It can still fail on environment or dependency differences a local run never sees.
 
-**Green CI does not mean the feature works.** Every automated test mocks Trac, by design, so the suite passes whether or not Trac still returns what the parser expects and whether or not the deployed Worker matches `main`. Only the smoke test answers those. Run it against `pnpm dev` before opening a PR that touches Trac parsing or MCP transport, and against the deployment after it ships.
+**Green CI does not mean the feature works.** Every automated test mocks Trac, by design, so the suite passes whether or not Trac still returns what the parser expects and whether or not the deployed Worker matches `trunk`. Only the smoke test answers those. Run it against `pnpm dev` before opening a PR that touches Trac parsing or MCP transport, and against the deployment after it ships.
 
 ## Where tests go
 


### PR DESCRIPTION
Prepares the repository for the default branch rename requested in #51, so the name matches other WordPress repositories.

- The CI workflow's `push` trigger now watches `trunk`.
- The tests contributor guide and the smoke-test doc now say `trunk` where they named the default branch.

The `main` keys in `package.json` and `wrangler.toml` are Worker entry points, not branch names, and are left alone.

The branch rename itself is a repository-settings change a maintainer has to make on GitHub (Settings → Branches → rename `main` to `trunk`). GitHub retargets open pull requests automatically; contributors will need to point their local clones at the new name. Merging this before the rename leaves CI without a `push` trigger until the rename happens, so renaming first and merging after is the smoother order — GitHub will retarget this pull request on its own.

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)