### PR TITLE
Serve every WordPress.org Trac instance from its own endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Green CI does not mean the feature works: every automated test mocks Trac. Follo
 - Keep upstream requests on `*.trac.wordpress.org` and the official linked-PR endpoint at `api.wordpress.org/dotorg/trac/pr/`.
 - Take the Trac instance from the endpoint path, never from a tool argument. Binding it to the connection is what stops a client reading the wrong Trac.
 - Expect fields to differ between instances. Report a field an instance does not configure as unavailable rather than failing, but keep failing when the page is not a Trac query page at all.
+- Never let a filter reach Trac on a field the instance does not configure. Trac ignores it and returns the unfiltered result set, which is indistinguishable from a real answer. Check against the filter picker Trac renders on every query page, and treat that list as the authority for which fields exist.
 - Return upstream failures as MCP tool errors.
 - Update README and manual checks when behavior changes.
 - Do not deploy without explicit maintainer approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-This repository provides a read-only MCP server for public WordPress Core Trac data. Preserve that trust boundary: no Trac writes, credentials, user-selected upstream hosts, or unbounded inputs.
+This repository provides a read-only MCP server for public WordPress.org Trac data. Preserve that trust boundary: no Trac writes, credentials, or unbounded inputs.
+
+The upstream host is derived from a URL path segment, so treat that derivation as security-relevant. A request may only reach `<slug>.trac.wordpress.org` where the slug matches `TRAC_SLUG_PATTERN`, and `fetchTrac` rechecks every URL against the resolved instance origin. Redirects are never followed: the domain has wildcard DNS and sends unknown subdomains to Core, so a followed redirect would silently answer for one instance with another's data.
 
 ## Work locally
 
@@ -25,7 +27,9 @@ Green CI does not mean the feature works: every automated test mocks Trac. Follo
 - Keep advertised JSON schemas and Zod runtime schemas aligned.
 - Add or update tests for parser, protocol, routing, and pagination behavior.
 - Treat Trac responses as untrusted input.
-- Keep upstream requests on `core.trac.wordpress.org` and the official linked-PR endpoint at `api.wordpress.org/dotorg/trac/pr/`.
+- Keep upstream requests on `*.trac.wordpress.org` and the official linked-PR endpoint at `api.wordpress.org/dotorg/trac/pr/`.
+- Take the Trac instance from the endpoint path, never from a tool argument. Binding it to the connection is what stops a client reading the wrong Trac.
+- Expect fields to differ between instances. Report a field an instance does not configure as unavailable rather than failing, but keep failing when the page is not a Trac query page at all.
 - Return upstream failures as MCP tool errors.
 - Update README and manual checks when behavior changes.
 - Do not deploy without explicit maintainer approval.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ severities. `getTracInfo` reports a field the instance does not configure as una
 failing. Ticket fields behave the same way: `focuses` exists only on Core and comes back empty
 elsewhere.
 
+Filtering is stricter, because Trac answers a filter on a field it does not configure with the
+unfiltered result set rather than an error, and that reads as a real match count. `searchTickets`
+rejects such a filter and names the fields the instance does have. This covers both the separate
+arguments and the expressions inside `query`.
+
 Connect to one instance per client entry. Use several entries to read several Tracs.
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # WordPress Trac MCP server
 
-A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server for
-[WordPress Core Trac](https://core.trac.wordpress.org/). It runs as a Cloudflare Worker and uses
-Trac's public HTML, CSV, RSS, and diff endpoints.
+A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server for the WordPress.org
+Trac instances, starting with [WordPress Core Trac](https://core.trac.wordpress.org/). It runs as a
+Cloudflare Worker and uses Trac's public HTML, CSV, RSS, and diff endpoints.
 
 Live servers:
 
@@ -21,6 +21,32 @@ Staging:
 The former staging deployment at `https://mcp-server-wporg-trac-staging.a8cai.workers.dev` is
 deprecated and runs older code. Its `a8cai.workers.dev` subdomain differs from the active staging
 deployment's `a8c-aiops.workers.dev` subdomain.
+
+## Trac instances
+
+Each Trac instance has its own endpoint. `/mcp` and `/mcp/chatgpt` serve Core.
+
+| Trac | Standard MCP | Search/fetch compatibility |
+| --- | --- | --- |
+| [WordPress Core](https://core.trac.wordpress.org/) | `/mcp` | `/mcp/chatgpt` |
+| [Making WordPress.org](https://meta.trac.wordpress.org/) | `/mcp/meta` | `/mcp/meta/chatgpt` |
+| [Themes](https://themes.trac.wordpress.org/) | `/mcp/themes` | `/mcp/themes/chatgpt` |
+| [Plugins](https://plugins.trac.wordpress.org/) | `/mcp/plugins` | `/mcp/plugins/chatgpt` |
+| [bbPress](https://bbpress.trac.wordpress.org/) | `/mcp/bbpress` | `/mcp/bbpress/chatgpt` |
+| [BuddyPress](https://buddypress.trac.wordpress.org/) | `/mcp/buddypress` | `/mcp/buddypress/chatgpt` |
+| [GlotPress](https://glotpress.trac.wordpress.org/) | `/mcp/glotpress` | `/mcp/glotpress/chatgpt` |
+| [Google Summer of Code](https://gsoc.trac.wordpress.org/) | `/mcp/gsoc` | `/mcp/gsoc/chatgpt` |
+
+The table is a discovery aid rather than an allowlist. Any `<slug>.trac.wordpress.org` resolves at
+`/mcp/<slug>`, so a Trac added later needs no change here. An instance is bound to the connection
+rather than chosen per tool call, so a client cannot read the wrong Trac by mistake.
+
+Instances configure different fields. Themes has no components, and only some instances have
+severities. `getTracInfo` reports a field the instance does not configure as unavailable instead of
+failing. Ticket fields behave the same way: `focuses` exists only on Core and comes back empty
+elsewhere.
+
+Connect to one instance per client entry. Use several entries to read several Tracs.
 
 ## Tools
 
@@ -45,6 +71,9 @@ The standard `/mcp` endpoint provides:
 
 The `/mcp/chatgpt` compatibility endpoint provides `search` and `fetch`. Use a bare number for a
 ticket and an `r` prefix for a changeset: `65739` and `r58504`.
+
+No tool takes a Trac instance argument. The endpoint you connect to decides which Trac the tools
+read.
 
 ### Search filters
 
@@ -74,6 +103,13 @@ bridge can use `mcp-remote`:
       "args": [
         "mcp-remote",
         "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp"
+      ]
+    },
+    "wordpress-meta-trac": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/mcp/meta"
       ]
     }
   }
@@ -123,8 +159,12 @@ pnpm run deploy:production
 
 - The server is read-only and has no Trac credentials.
 - Tool inputs receive runtime validation before any upstream request.
-- Upstream requests use the fixed `core.trac.wordpress.org` host and the official linked-PR
-  endpoint on `api.wordpress.org`.
+- Upstream requests stay on `*.trac.wordpress.org` and the official linked-PR endpoint on
+  `api.wordpress.org`. The instance slug comes from the URL path, is validated against a strict
+  pattern before it reaches a request, and every request is checked against the resolved origin.
+- Upstream redirects are never followed. `*.trac.wordpress.org` has wildcard DNS and redirects
+  unknown subdomains to Core, so following one would answer for one instance with another's data.
+  A redirect is reported as an unknown instance instead.
 - Transient transport failures, rate limits, server errors, and Trac bot challenges receive bounded
   retries. Permanent 403 and 404 responses return immediately.
 - Responses are parsed from public Trac pages and machine-readable formats.

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -40,8 +40,6 @@ Argument names are easy to guess wrong. The real ones:
 
 `getTicket` takes `id`, not `ticketId`. `getTracInfo` takes `type`, not `infoType`. `getChangeset` takes `revision`, not `rev`.
 
-No tool takes a Trac instance argument. The endpoint path selects the instance, so `call /mcp ...` reads Core and `call /mcp/meta ...` reads Making WordPress.org. Sections 1 to 6 all run against Core; section 7 covers the other instances.
-
 ## 1. Transport surface
 
 ```bash

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -40,6 +40,8 @@ Argument names are easy to guess wrong. The real ones:
 
 `getTicket` takes `id`, not `ticketId`. `getTracInfo` takes `type`, not `infoType`. `getChangeset` takes `revision`, not `rev`.
 
+No tool takes a Trac instance argument. The endpoint path selects the instance, so `call /mcp ...` reads Core and `call /mcp/meta ...` reads Making WordPress.org. Sections 1 to 6 all run against Core; section 7 covers the other instances.
+
 ## 1. Transport surface
 
 ```bash
@@ -131,6 +133,75 @@ call /mcp getTracInfo '{}'
 ```
 
 Every one of these returns a JSON-RPC error rather than a success envelope or a crash. Bad arguments come back as `-32602` invalid params with the failing field named. A malformed request that returns `200` with empty content is a bug.
+
+## 7. Other Trac instances
+
+Each instance is a separate endpoint. These fixtures live on Meta rather than Core:
+
+| Fixture | Covers |
+| --- | --- |
+| `meta` `5483` | Ticket with comments on a non-Core instance |
+| `meta` `r14000` | Changeset on a non-Core instance |
+| `meta` `severities` | A field the instance does not configure |
+| `themes` `components` | A second, differently shaped missing field |
+| `xyzzy-nope` | A slug that resolves but has no Trac behind it |
+
+Confirm one non-Core instance end to end:
+
+```bash
+rpc  /mcp/meta '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+call /mcp/meta searchTickets '{"query":"plugin","limit":2}'
+call /mcp/meta getTicket '{"id":5483,"includeComments":true,"commentLimit":2}'
+call /mcp/meta getChangeset '{"revision":14000,"includeDiff":false}'
+call /mcp/meta getTimeline '{"days":7,"limit":3}'
+call /mcp/meta getTracInfo '{"type":"components"}'
+call /mcp/meta/chatgpt search '{"query":"5483"}'
+call /mcp/meta/chatgpt fetch '{"id":"r14000"}'
+```
+
+`initialize` names the instance: `Making WordPress.org Trac` rather than `WordPress Trac`. Every `url` in a result points at `meta.trac.wordpress.org`. A result carrying a `core.trac.wordpress.org` URL means the instance was not threaded through, which is the failure this section exists to catch.
+
+Then confirm the rest still answer:
+
+```bash
+for slug in themes plugins bbpress buddypress glotpress gsoc; do
+  echo "== $slug"; call "/mcp/$slug" searchTickets '{"limit":1}'
+done
+```
+
+Each returns tickets whose `url` matches its own instance. Instances differ in size and in which fields they configure, so judge these on the request succeeding and the host being right rather than on the counts.
+
+### Fields an instance does not have
+
+```bash
+call /mcp/meta   getTracInfo '{"type":"severities"}'
+call /mcp/themes getTracInfo '{"type":"components"}'
+call /mcp        getTracInfo '{"type":"severities"}'
+```
+
+Meta has no severities and Themes has no components. Both return `Severities are not available in ...` / `Components are not available in ...` with `metadata.total` of `0`, and neither is a tool error. Core still returns the populated list, which is the control: an empty answer there means the query page markup changed and the parser broke.
+
+### Unknown instances
+
+```bash
+call /mcp/xyzzy-nope getTicket '{"id":65739}'
+call /mcp/xyzzy-nope searchTickets '{"query":"editor","limit":1}'
+```
+
+Both return a tool error reading `Unknown or unavailable Trac instance: xyzzy-nope`.
+
+This is the most important check in this section. `*.trac.wordpress.org` has wildcard DNS and redirects every unknown subdomain to Core, so a server that follows redirects answers these with Core's ticket 65739 and a populated search, looking entirely healthy. Core data here is a security regression, not a cosmetic one.
+
+### Rejected paths
+
+```bash
+for p in /mcp/ /mcp/Meta /mcp/meta/ /mcp/meta/tools /mcp/chatgpt/chatgpt; do
+  printf '%-22s %s\n' "$p" "$(curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$BASE$p" \
+    -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"ping"}')"
+done
+```
+
+All five return `404`. Slugs are lowercase, so `/mcp/Meta` is rejected rather than folded to `/mcp/meta`. `chatgpt` is a route keyword rather than an instance, so `/mcp/chatgpt` stays Core's compatibility endpoint and `/mcp/chatgpt/chatgpt` resolves to nothing.
 
 ## Reading a failure
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -181,6 +181,17 @@ call /mcp        getTracInfo '{"type":"severities"}'
 
 Meta has no severities and Themes has no components. Both return `Severities are not available in ...` / `Components are not available in ...` with `metadata.total` of `0`, and neither is a tool error. Core still returns the populated list, which is the control: an empty answer there means the query page markup changed and the parser broke.
 
+Filtering on such a field is a tool error rather than an unavailable answer:
+
+```bash
+call /mcp/themes searchTickets '{"component":"Widgets","limit":2}'
+call /mcp/meta   searchTickets '{"query":"focuses~=accessibility","limit":2}'
+call /mcp/meta   searchTickets '{"component":"Plugin Directory","limit":2}'
+call /mcp        searchTickets '{"component":"Widgets","limit":2}'
+```
+
+The first two fail with `has no component field` / `has no focuses field` and list the fields that instance does have. The last two succeed, because Meta configures components and Core configures both. The difference matters: Trac answers a filter on a field it does not configure with the whole ticket set and a matching `totalFound`, so a passing-looking result here is the bug, not the error.
+
 ### Unknown instances
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,8 @@ This includes:
 
 Tests mock Trac responses. They should not depend on Trac availability or mutable ticket content.
 
+Mocked tests cannot see the one failure that matters most for multiple instances: `*.trac.wordpress.org` redirects unknown subdomains to Core, so a server that follows redirects answers for the wrong Trac while every mocked test passes. The automated suite pins the guard against that, and step 10 of the smoke test confirms it against the live domain.
+
 ## Manual smoke test
 
 Start the Worker by following [local-development.md](local-development.md), then use harmless public ticket and changeset IDs. See [smoke-test.md](smoke-test.md) for the same list as runnable commands with expected results.
@@ -36,6 +38,9 @@ Start the Worker by following [local-development.md](local-development.md), then
 5. Check search page 1 and a page beyond the final result; the latter should return an empty page.
 6. Initialize `/mcp/chatgpt`, then search a keyword, ticket `65739`, and changeset `r58504`.
 7. Send invalid arguments and confirm the response is a JSON-RPC invalid-params error.
+8. Exercise a non-Core instance at `/mcp/meta` and `/mcp/meta/chatgpt`. Every URL in a result must point at `meta.trac.wordpress.org`; a `core.trac.wordpress.org` URL means the instance was not threaded through.
+9. Ask an instance for a field it does not configure, such as severities on `/mcp/meta`. Expect an "are not available" answer rather than a tool error, and confirm Core still returns its populated list.
+10. Call a tool on a slug with no Trac behind it, such as `/mcp/xyzzy-nope`. Expect `Unknown or unavailable Trac instance`. Core data here is a security regression: the domain redirects unknown subdomains to Core, so a server that follows redirects fails this check while looking healthy.
 
 Do not paste private ticket data or credentials into fixtures. If live checks fail, distinguish a Trac response change from Worker behavior before changing a parser.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -621,7 +621,7 @@ describe('Trac instance routing', () => {
         .fn<typeof fetch>()
         .mockResolvedValue(
           new Response(
-            '<html><body><select name="add_filter_0"></select><select name="0_severity"><option value="blocker">blocker</option><option value="normal">normal</option></select></body></html>'
+            '<html><body><select name="add_filter_0"><option value="severity">Severity</option></select><select class="trac-filter" name="0_severity"><option value="blocker">blocker</option><option value="normal">normal</option></select></body></html>'
           )
         )
     );
@@ -686,7 +686,12 @@ describe('Trac instance routing', () => {
     async (query) => {
       vi.stubGlobal(
         'fetch',
-        vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 301 }))
+        vi.fn<typeof fetch>().mockResolvedValue(
+          new Response(null, {
+            status: 301,
+            headers: { location: 'https://core.trac.wordpress.org/query' },
+          })
+        )
       );
 
       const response = await mcpRequest(
@@ -742,6 +747,159 @@ describe('Trac instance routing', () => {
 
       expect(response.status).toBe(404);
     }
+  });
+
+  it('refuses a search filtering on a field the routed instance does not configure', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('id,summary\n286473,A theme'))
+      .mockResolvedValueOnce(
+        new Response(
+          '<html><select name="add_filter_0"><option value="status">Status</option><option value="keywords">Keywords</option></select><span class="numrows">(149 matches)</span></html>'
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'searchTickets', arguments: { component: 'Widgets' } },
+      },
+      '/mcp/themes'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    const text = body.result.content.at(0)?.text ?? '';
+    expect(text).toContain('has no component field');
+    expect(text).toContain('keywords, status');
+  });
+
+  it('refuses a filter expression naming a field only other instances configure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary\n5483,A meta ticket'))
+        .mockResolvedValueOnce(
+          new Response(
+            '<html><select name="add_filter_0"><option value="component">Component</option><option value="status">Status</option></select><span class="numrows">(1117 matches)</span></html>'
+          )
+        )
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'searchTickets', arguments: { query: 'focuses~=accessibility' } },
+      },
+      '/mcp/meta'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content.at(0)?.text).toContain('has no focuses field');
+  });
+
+  it('allows a search filtering on a field the routed instance does configure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response('id,summary,component\n5483,A meta ticket,Plugin Directory')
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            '<html><select name="add_filter_0"><option value="component">Component</option></select><span class="numrows">(3 matches)</span></html>'
+          )
+        )
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'searchTickets', arguments: { component: 'Plugin Directory' } },
+      },
+      '/mcp/meta'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBeUndefined();
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}').totalFound).toBe(3);
+  });
+
+  it('fails rather than reporting a configured field as unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(
+            '<html><select name="add_filter_0"><option value="component">Component</option></select><p>the option list moved</p></html>'
+          )
+        )
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTracInfo', arguments: { type: 'components' } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content.at(0)?.text).toContain('Trac did not return component options');
+  });
+
+  it('reads the option list whatever order Trac writes the select attributes in', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(
+            '<html><select id="filter" name="add_filter_0"><option value="component">Component</option></select><select class="trac-filter" id="c" name="0_component"><option value="Editor">Editor</option></select></html>'
+          )
+        )
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTracInfo', arguments: { type: 'components' } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBeUndefined();
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}').metadata.data).toEqual(['Editor']);
+  });
+
+  it('reports a redirect that stays on the instance as a redirect, not a missing instance', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://meta.trac.wordpress.org/maintenance' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const instance = tracInstance('meta');
+    if (!instance) {
+      throw new Error('meta should resolve');
+    }
+
+    await expect(
+      fetchTrac(instance, 'https://meta.trac.wordpress.org/timeline', undefined, [0])
+    ).rejects.toThrow('Unexpected redirect from https://meta.trac.wordpress.org: HTTP 302');
   });
 
   it('reports a field the routed instance does not configure as unavailable', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,10 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import worker, {
   addTicketSearchQuery,
   cleanTracText,
+  CORE_TRAC,
   fetchTrac,
+  matchMcpRoute,
   parseCsvRecords,
   parseTicketFilter,
   searchTracTickets,
+  tracInstance,
 } from './index';
 
 const context = {} as ExecutionContext;
@@ -122,7 +125,7 @@ describe('ticket search pagination', () => {
       .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(searchTracTickets('', 10, 85)).resolves.toEqual({
+    await expect(searchTracTickets(CORE_TRAC, '', 10, 85)).resolves.toEqual({
       tickets: [],
       totalFound: 840,
       returned: 0,
@@ -145,6 +148,7 @@ describe('Trac retries', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const response = await fetchTrac(
+      CORE_TRAC,
       'https://core.trac.wordpress.org/timeline',
       undefined,
       [0, 0, 0, 0]
@@ -163,7 +167,12 @@ describe('Trac retries', () => {
       .mockResolvedValue(new Response(statusText, { status, statusText }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const response = await fetchTrac('https://core.trac.wordpress.org/timeline', undefined, [0]);
+    const response = await fetchTrac(
+      CORE_TRAC,
+      'https://core.trac.wordpress.org/timeline',
+      undefined,
+      [0]
+    );
 
     expect(response.status).toBe(status);
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -175,7 +184,12 @@ describe('Trac retries', () => {
       .mockResolvedValue(new Response('Unavailable', { status: 503 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const response = await fetchTrac('https://core.trac.wordpress.org/timeline', undefined, [0, 0]);
+    const response = await fetchTrac(
+      CORE_TRAC,
+      'https://core.trac.wordpress.org/timeline',
+      undefined,
+      [0, 0]
+    );
 
     expect(response.status).toBe(503);
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -185,9 +199,9 @@ describe('Trac retries', () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(fetchTrac('https://example.com/timeline', undefined, [0])).rejects.toThrow(
-      'Refusing non-Trac request host'
-    );
+    await expect(
+      fetchTrac(CORE_TRAC, 'https://example.com/timeline', undefined, [0])
+    ).rejects.toThrow('Refusing non-Trac request host');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
@@ -510,4 +524,270 @@ describe('MCP transport', () => {
       expect(result).toEqual({ results: [], query, totalFound: 0 });
     }
   );
+});
+
+describe('Trac instance routing', () => {
+  it.each([
+    ['/mcp', 'core', false],
+    ['/mcp/chatgpt', 'core', true],
+    ['/mcp/meta', 'meta', false],
+    ['/mcp/meta/chatgpt', 'meta', true],
+    ['/mcp/glotpress', 'glotpress', false],
+  ])('routes %s to the %s instance', (pathname, slug, chatGpt) => {
+    expect(matchMcpRoute(pathname)).toEqual({
+      instance: expect.objectContaining({
+        slug,
+        origin: `https://${slug}.trac.wordpress.org`,
+      }),
+      chatGpt,
+    });
+  });
+
+  it.each([
+    ['/mcp/', 'an empty slug'],
+    ['/mcp/meta/', 'a trailing slash'],
+    ['/mcp/meta/tools', 'an unknown trailing segment'],
+    ['/mcp/meta/chatgpt/extra', 'an over-long path'],
+    ['/mcp/chatgpt/chatgpt', 'the reserved chatgpt slug'],
+    ['/mcp/Meta', 'an uppercase slug'],
+    ['/mcp/meta.trac.wordpress.org', 'a dotted slug'],
+    ['/mcp/%6Deta', 'a percent-encoded slug, which URL parsing leaves encoded'],
+    ['/mcpx', 'a different path'],
+    ['/', 'the landing page'],
+  ])('refuses %s (%s)', (pathname) => {
+    expect(matchMcpRoute(pathname)).toBeNull();
+  });
+
+  it('refuses reserved and malformed slugs', () => {
+    expect(tracInstance('chatgpt')).toBeNull();
+    expect(tracInstance('')).toBeNull();
+    expect(tracInstance('-leading')).toBeNull();
+    expect(tracInstance('trailing-')).toBeNull();
+    expect(tracInstance('a'.repeat(33))).toBeNull();
+    expect(tracInstance('meta')?.origin).toBe('https://meta.trac.wordpress.org');
+  });
+
+  it('answers an unroutable instance path with 404 rather than core data', async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await mcpRequest({ jsonrpc: '2.0', id: 1, method: 'ping' }, '/mcp/Meta');
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('treats an upstream redirect as an unknown instance instead of following it', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 301,
+        headers: { location: 'https://core.trac.wordpress.org/timeline' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const instance = tracInstance('xyzzy-nope');
+    if (!instance) {
+      throw new Error('A well-formed slug should resolve regardless of whether the Trac exists');
+    }
+
+    await expect(
+      fetchTrac(instance, 'https://xyzzy-nope.trac.wordpress.org/timeline', undefined, [0, 0])
+    ).rejects.toThrow('Unknown or unavailable Trac instance: xyzzy-nope');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe('manual');
+  });
+
+  it('serves core under its own name at both slugless endpoints', async () => {
+    for (const path of ['/mcp', '/mcp/chatgpt']) {
+      const response = await mcpRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }, path);
+
+      expect(await response.json()).toEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'WordPress Trac', version: '1.0.0' },
+        },
+      });
+    }
+  });
+
+  it('names core in the tool output that carries an instance name', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(
+            '<html><body><select name="add_filter_0"></select><select name="0_severity"><option value="blocker">blocker</option><option value="normal">normal</option></select></body></html>'
+          )
+        )
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTracInfo', arguments: { type: 'severities' } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      id: 'severities',
+      title: 'WordPress Trac severities',
+      text: 'Severities available in WordPress Trac:\n\nblocker\nnormal',
+      url: 'https://core.trac.wordpress.org/',
+      metadata: { type: 'severities', data: ['blocker', 'normal'], total: 2 },
+    });
+  });
+
+  it('names a non-core instance after its Trac', async () => {
+    const response = await mcpRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }, '/mcp/meta');
+    const body = (await response.json()) as { result: { serverInfo: { name: string } } };
+
+    expect(body.result.serverInfo.name).toBe('Making WordPress.org Trac');
+  });
+
+  it('reads tickets from the routed instance and its linked pull requests', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('id,summary,status\n5483,Release confirmations,new'))
+      .mockResolvedValueOnce(
+        new Response(
+          '<?xml version="1.0"?><rss><channel><description>Meta ticket</description></channel></rss>'
+        )
+      )
+      .mockResolvedValueOnce(Response.json([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'getTicket', arguments: { id: 5483 } },
+      },
+      '/mcp/meta'
+    );
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    const requested = fetchMock.mock.calls.map((call) => call[0]?.toString() ?? '');
+    expect(requested[0]).toContain('https://meta.trac.wordpress.org/query');
+    expect(requested[1]).toBe('https://meta.trac.wordpress.org/ticket/5483?format=rss');
+    expect(requested[2]).toBe('https://api.wordpress.org/dotorg/trac/pr/?trac=meta&ticket=5483');
+    expect(result.url).toBe('https://meta.trac.wordpress.org/ticket/5483');
+  });
+
+  it.each(['65739', 'r58504', 'editor'])(
+    'surfaces an unknown instance for compatibility search %s rather than an empty result',
+    async (query) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 301 }))
+      );
+
+      const response = await mcpRequest(
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'search', arguments: { query } },
+        },
+        '/mcp/xyzzy-nope/chatgpt'
+      );
+      const body = (await response.json()) as RpcBody;
+
+      expect(body.result.isError).toBe(true);
+      expect(body.result.content.at(0)?.text).toContain('Unknown or unavailable Trac instance');
+    }
+  );
+
+  it('still returns an empty compatibility search when a direct lookup simply misses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' }))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'search', arguments: { query: '99999999' } },
+      },
+      '/mcp/meta/chatgpt'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBeUndefined();
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}')).toEqual({
+      results: [],
+      query: '99999999',
+      totalFound: 0,
+    });
+  });
+
+  it('answers every method on an unroutable instance path with 404', async () => {
+    for (const method of ['POST', 'OPTIONS', 'GET']) {
+      const response = await worker.fetch(
+        new Request('https://example.com/mcp/Meta', { method }),
+        {},
+        context
+      );
+
+      expect(response.status).toBe(404);
+    }
+  });
+
+  it('reports a field the routed instance does not configure as unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(
+            '<html><body><select name="add_filter_0"><option value="status">Status</option></select></body></html>'
+          )
+        )
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'getTracInfo', arguments: { type: 'severities' } },
+      },
+      '/mcp/meta'
+    );
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(body.result.isError).toBeUndefined();
+    expect(result.metadata.data).toEqual([]);
+    expect(result.text).toBe('Severities are not available in Making WordPress.org Trac.');
+  });
+
+  it('still fails when a field page is not a Trac query page at all', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(new Response('<html><body>Maintenance</body></html>'))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTracInfo', arguments: { type: 'severities' } },
+    });
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content.at(0)?.text).toContain('Trac did not return severity options');
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -902,6 +902,99 @@ describe('Trac instance routing', () => {
     ).rejects.toThrow('Unexpected redirect from https://meta.trac.wordpress.org: HTTP 302');
   });
 
+  it('fails a filtered search when the count page cannot confirm the field exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary\n286473,A theme'))
+        .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'searchTickets', arguments: { component: 'Widgets' } },
+      },
+      '/mcp/themes'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content.at(0)?.text).toContain('Cannot confirm the component filter');
+  });
+
+  it('still degrades gracefully when the count page fails and nothing was filtered', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary\n286473,A theme'))
+        .mockResolvedValueOnce(new Response('Bad Request', { status: 400 }))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'searchTickets', arguments: { limit: 5 } },
+      },
+      '/mcp/themes'
+    );
+    const body = (await response.json()) as RpcBody;
+
+    expect(body.result.isError).toBeUndefined();
+    expect(JSON.parse(body.result.content.at(0)?.text ?? '{}').returned).toBe(1);
+  });
+
+  it('separates a field an instance lacks from one no ticket has a value for', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockResolvedValue(new Response('id,milestone\n4,\n5,'))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'getTracInfo', arguments: { type: 'milestones' } },
+      },
+      '/mcp/gsoc'
+    );
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(result.metadata.data).toEqual([]);
+    expect(result.text).toBe('No milestones found in Google Summer of Code Trac.');
+  });
+
+  it('follows a redirect from the linked pull request endpoint', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('id,summary,status\n65808,REST API ticket,closed'))
+      .mockResolvedValueOnce(
+        new Response(
+          '<?xml version="1.0"?><rss><channel><description>Ticket description</description></channel></rss>'
+        )
+      )
+      .mockResolvedValueOnce(Response.json([linkedPullRequestFixture()]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'getTicket', arguments: { id: 65808 } },
+    });
+
+    expect(fetchMock.mock.calls[2]?.[0]?.toString()).toContain('api.wordpress.org');
+    expect(fetchMock.mock.calls[2]?.[1]?.redirect).toBeUndefined();
+  });
+
   it('reports a field the routed instance does not configure as unavailable', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,9 +78,73 @@ const LinkedPullRequestSchema = z.object({
 
 class UnknownToolError extends Error {}
 
+/*
+ * Distinct from an ordinary upstream failure so callers that turn "not found"
+ * into an empty result do not also swallow a Trac that does not exist.
+ */
+class UnknownTracInstanceError extends Error {}
+
 const TRAC_USER_AGENT = 'Mozilla/5.0 (compatible; WordPress-Trac-MCP-Server/1.0)';
-const TRAC_ORIGIN = 'https://core.trac.wordpress.org';
 const TRAC_RETRY_DELAYS_MS = [2000, 4000, 8000] as const;
+
+const TRAC_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+
+/*
+ * `chatgpt` is a route keyword rather than an instance, so /mcp/chatgpt keeps
+ * meaning "core, ChatGPT tools" instead of resolving a Trac named chatgpt.
+ */
+const RESERVED_TRAC_SLUGS = new Set(['chatgpt']);
+
+/*
+ * Known instances, in landing page order. Any other well-formed slug still
+ * resolves and falls back to its slug as a label; this is a discovery aid
+ * rather than an allowlist.
+ */
+const TRAC_LABELS: Record<string, string> = {
+  core: 'WordPress',
+  meta: 'Making WordPress.org',
+  themes: 'WordPress Themes',
+  plugins: 'WordPress Plugins',
+  bbpress: 'bbPress',
+  buddypress: 'BuddyPress',
+  glotpress: 'GlotPress',
+  gsoc: 'Google Summer of Code',
+};
+
+export type TracInstance = {
+  slug: string;
+  origin: string;
+  label: string;
+};
+
+function makeTracInstance(slug: string): TracInstance {
+  return {
+    slug,
+    origin: `https://${slug}.trac.wordpress.org`,
+    label: TRAC_LABELS[slug] ?? slug,
+  };
+}
+
+/**
+ * Resolve a URL path segment to a Trac instance.
+ *
+ * @param slug Subdomain label of a *.trac.wordpress.org instance.
+ * @return The instance, or null when the slug is malformed or reserved.
+ */
+export function tracInstance(slug: string): TracInstance | null {
+  return TRAC_SLUG_PATTERN.test(slug) && !RESERVED_TRAC_SLUGS.has(slug)
+    ? makeTracInstance(slug)
+    : null;
+}
+
+export const CORE_TRAC = makeTracInstance('core');
+
+/**
+ * Human-readable name for an instance, used in server info and tool output.
+ */
+function tracDisplayName(instance: TracInstance): string {
+  return `${instance.label} Trac`;
+}
 const TICKET_COLUMNS = [
   'id',
   'summary',
@@ -123,26 +187,39 @@ async function isTransientTracResponse(response: Response): Promise<boolean> {
   return /Checking your browser/i.test(await response.clone().text());
 }
 
+function isRedirect(response: Response): boolean {
+  return response.redirected || (response.status >= 300 && response.status < 400);
+}
+
 export async function fetchTrac(
+  instance: TracInstance,
   input: string | URL,
   init?: RequestInit,
   retryDelays: readonly number[] = TRAC_RETRY_DELAYS_MS
 ): Promise<Response> {
   const url = new URL(input);
-  if (url.origin !== TRAC_ORIGIN) {
+  if (url.origin !== instance.origin) {
     throw new Error(`Refusing non-Trac request host: ${url.hostname}`);
   }
 
   for (let attempt = 0; ; attempt++) {
+    let response: Response;
     try {
-      const response = await fetch(url.toString(), init);
-      if (!(await isTransientTracResponse(response)) || attempt >= retryDelays.length) {
-        return response;
-      }
+      // Unknown subdomains redirect to core, so following one would answer with another instance's data.
+      response = await fetch(url.toString(), { ...init, redirect: 'manual' });
     } catch (error) {
       if (attempt >= retryDelays.length) {
         throw error;
       }
+      await wait(retryDelays[attempt] ?? 0);
+      continue;
+    }
+
+    if (isRedirect(response)) {
+      throw new UnknownTracInstanceError(`Unknown or unavailable Trac instance: ${instance.slug}`);
+    }
+    if (!(await isTransientTracResponse(response)) || attempt >= retryDelays.length) {
+      return response;
     }
 
     await wait(retryDelays[attempt] ?? 0);
@@ -347,6 +424,7 @@ type ClassifiedTicketHistory =
   | { kind: 'comment'; entry: TicketHistoryEntry };
 
 function classifyTicketHistoryItem(
+  instance: TracInstance,
   ticketId: number,
   item: RssItem
 ): ClassifiedTicketHistory | null {
@@ -368,7 +446,7 @@ function classifyTicketHistoryItem(
         timestamp: item.date,
         description: parsedDescription.body,
         url: filename
-          ? `https://core.trac.wordpress.org/raw-attachment/ticket/${ticketId}/${encodeURIComponent(filename)}`
+          ? `${instance.origin}/raw-attachment/ticket/${ticketId}/${encodeURIComponent(filename)}`
           : '',
       },
     };
@@ -388,7 +466,7 @@ function classifyTicketHistoryItem(
         timestamp: item.date,
         changes: filterTicketFieldChurn(item.title),
         message: cleanTracText(narrativeHtml.slice(changesetMatch[0].length)),
-        url: `https://core.trac.wordpress.org/changeset/${revision}`,
+        url: `${instance.origin}/changeset/${revision}`,
       },
     };
   }
@@ -411,13 +489,13 @@ function classifyTicketHistoryItem(
   };
 }
 
-function classifyTicketHistory(ticketId: number, rssText: string) {
+function classifyTicketHistory(instance: TracInstance, ticketId: number, rssText: string) {
   const comments: TicketHistoryEntry[] = [];
   const attachments: TicketAttachment[] = [];
   const changesets: TicketChangeset[] = [];
 
   for (const item of parseRssItems(rssText)) {
-    const classified = classifyTicketHistoryItem(ticketId, item);
+    const classified = classifyTicketHistoryItem(instance, ticketId, item);
     if (classified?.kind === 'comment') {
       comments.push(classified.entry);
     } else if (classified?.kind === 'attachment') {
@@ -493,8 +571,8 @@ export function addTicketSearchQuery(url: URL, query: string): void {
   }
 }
 
-async function fetchCsvRecords(url: URL): Promise<TracRecord[]> {
-  const response = await fetchTrac(url, {
+async function fetchCsvRecords(instance: TracInstance, url: URL): Promise<TracRecord[]> {
+  const response = await fetchTrac(instance, url, {
     headers: {
       'User-Agent': TRAC_USER_AGENT,
       Accept: 'text/csv,text/plain,*/*',
@@ -534,9 +612,12 @@ function ticketFromRecord(record: TracRecord) {
   };
 }
 
-async function fetchLinkedPullRequests(ticketId: number): Promise<LinkedPullRequest[]> {
+async function fetchLinkedPullRequests(
+  instance: TracInstance,
+  ticketId: number
+): Promise<LinkedPullRequest[]> {
   const pullRequestsUrl = new URL('https://api.wordpress.org/dotorg/trac/pr/');
-  pullRequestsUrl.searchParams.set('trac', 'core');
+  pullRequestsUrl.searchParams.set('trac', instance.slug);
   pullRequestsUrl.searchParams.set('ticket', ticketId.toString());
 
   const response = await fetch(pullRequestsUrl.toString(), {
@@ -544,7 +625,11 @@ async function fetchLinkedPullRequests(ticketId: number): Promise<LinkedPullRequ
       'User-Agent': TRAC_USER_AGENT,
       Accept: 'application/json',
     },
+    redirect: 'manual',
   });
+  if (isRedirect(response)) {
+    throw new Error('Failed to fetch linked pull requests: unexpected redirect');
+  }
   if (!response.ok) {
     throw new Error(`Failed to fetch linked pull requests: ${response.statusText}`);
   }
@@ -575,12 +660,13 @@ async function fetchLinkedPullRequests(ticketId: number): Promise<LinkedPullRequ
 }
 
 export async function searchTracTickets(
+  instance: TracInstance,
   query: string,
   limit: number,
   page: number,
   filters: TicketSearchFilters = {}
 ) {
-  const queryUrl = new URL('https://core.trac.wordpress.org/query');
+  const queryUrl = new URL(`${instance.origin}/query`);
   const pageSize = Math.min(Math.max(Math.trunc(limit), 1), 50);
   const pageNumber = Math.max(Math.trunc(page), 1);
   queryUrl.searchParams.set('format', 'csv');
@@ -609,8 +695,8 @@ export async function searchTracTickets(
   totalUrl.searchParams.delete('format');
   totalUrl.searchParams.delete('page');
   const [records, totalResponse] = await Promise.all([
-    fetchCsvRecords(queryUrl),
-    fetchTrac(totalUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
+    fetchCsvRecords(instance, queryUrl),
+    fetchTrac(instance, totalUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
   ]);
   const tickets = records.map(ticketFromRecord);
   if (!totalResponse.ok) {
@@ -641,18 +727,23 @@ export async function searchTracTickets(
   };
 }
 
-async function fetchTicket(ticketId: number, includeComments: boolean, commentLimit = 10) {
-  const queryUrl = new URL('https://core.trac.wordpress.org/query');
+async function fetchTicket(
+  instance: TracInstance,
+  ticketId: number,
+  includeComments: boolean,
+  commentLimit = 10
+) {
+  const queryUrl = new URL(`${instance.origin}/query`);
   queryUrl.searchParams.set('format', 'csv');
   queryUrl.searchParams.set('max', '1');
   queryUrl.searchParams.set('id', ticketId.toString());
   addColumns(queryUrl, TICKET_COLUMNS);
 
-  const rssUrl = `https://core.trac.wordpress.org/ticket/${ticketId}?format=rss`;
+  const rssUrl = `${instance.origin}/ticket/${ticketId}?format=rss`;
   const [records, rssResponse, linkedPullRequestsResult] = await Promise.all([
-    fetchCsvRecords(queryUrl),
-    fetchTrac(rssUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
-    fetchLinkedPullRequests(ticketId)
+    fetchCsvRecords(instance, queryUrl),
+    fetchTrac(instance, rssUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
+    fetchLinkedPullRequests(instance, ticketId)
       .then((linkedPullRequests) => ({ linkedPullRequests, unavailable: false }))
       .catch(() => ({ linkedPullRequests: [], unavailable: true })),
   ]);
@@ -665,7 +756,7 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
   const rssText = await rssResponse.text();
   const channel = rssText.split(/<item>/i, 1)[0] ?? '';
   const description = cleanTracText(extractXmlElement(channel, 'description'));
-  const history = classifyTicketHistory(ticketId, rssText);
+  const history = classifyTicketHistory(instance, ticketId, rssText);
   const limit = Math.min(Math.max(Math.trunc(commentLimit), 0), 50);
   const comments = includeComments && limit > 0 ? history.comments.slice(-limit) : [];
   const ticket = { ...ticketFromRecord(record), description };
@@ -682,6 +773,7 @@ async function fetchTicket(ticketId: number, includeComments: boolean, commentLi
 }
 
 function formatTicketResult(
+  instance: TracInstance,
   ticketData: Awaited<ReturnType<typeof fetchTicket>>,
   includeComments: boolean,
   stringId = false
@@ -768,7 +860,7 @@ Focuses: ${ticket.focuses}
 
 Description:
 ${ticket.description}${linkedPullRequestsText}${attachmentsText}${changesetsText}${historyText}`,
-    url: `https://core.trac.wordpress.org/ticket/${ticket.id}`,
+    url: `${instance.origin}/ticket/${ticket.id}`,
     metadata: {
       ticket,
       comments,
@@ -782,9 +874,14 @@ ${ticket.description}${linkedPullRequestsText}${attachmentsText}${changesetsText
   };
 }
 
-async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit = 2000) {
-  const changesetUrl = `https://core.trac.wordpress.org/changeset/${revision}`;
-  const response = await fetchTrac(changesetUrl, {
+async function fetchChangeset(
+  instance: TracInstance,
+  revision: number,
+  includeDiff: boolean,
+  diffLimit = 2000
+) {
+  const changesetUrl = `${instance.origin}/changeset/${revision}`;
+  const response = await fetchTrac(instance, changesetUrl, {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
 
@@ -810,7 +907,7 @@ async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit 
   let diff = '';
   if (includeDiff) {
     try {
-      const diffResponse = await fetchTrac(`${changesetUrl}?format=diff`, {
+      const diffResponse = await fetchTrac(instance, `${changesetUrl}?format=diff`, {
         headers: { 'User-Agent': TRAC_USER_AGENT },
       });
       if (diffResponse.ok) {
@@ -829,6 +926,7 @@ async function fetchChangeset(revision: number, includeDiff: boolean, diffLimit 
 }
 
 function formatChangesetResult(
+  instance: TracInstance,
   changeset: Awaited<ReturnType<typeof fetchChangeset>>,
   prefixedId = false
 ) {
@@ -848,7 +946,7 @@ Files changed: ${changeset.files.length}
 ${filesText}${changeset.files.length > 10 ? '\n...' : ''}
 
 ${changeset.diff ? `Diff:\n${changeset.diff}` : 'No diff available'}`,
-    url: `https://core.trac.wordpress.org/changeset/${changeset.revision}`,
+    url: `${instance.origin}/changeset/${changeset.revision}`,
     metadata: {
       changeset,
       totalFiles: changeset.files.length,
@@ -856,10 +954,13 @@ ${changeset.diff ? `Diff:\n${changeset.diff}` : 'No diff available'}`,
   };
 }
 
-async function fetchTracFieldOptions(field: 'component' | 'severity'): Promise<string[]> {
-  const queryUrl = new URL('https://core.trac.wordpress.org/query');
+async function fetchTracFieldOptions(
+  instance: TracInstance,
+  field: 'component' | 'severity'
+): Promise<string[]> {
+  const queryUrl = new URL(`${instance.origin}/query`);
   queryUrl.searchParams.set(field, '');
-  const response = await fetchTrac(queryUrl, {
+  const response = await fetchTrac(instance, queryUrl, {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
 
@@ -872,7 +973,11 @@ async function fetchTracFieldOptions(field: 'component' | 'severity'): Promise<s
     new RegExp(`<select\\s+name="0_${field}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i')
   )?.[1];
   if (!select) {
-    throw new Error(`Trac did not return ${field} options`);
+    // The filter picker renders on every query page, so its absence means this is not one.
+    if (!/<select\s+name="add_filter_0"/i.test(html)) {
+      throw new Error(`Trac did not return ${field} options`);
+    }
+    return [];
   }
 
   return Array.from(select.matchAll(/<option[^>]*value="([^"]+)"[^>]*>/gi), (match) =>
@@ -888,9 +993,9 @@ type TracInfoType =
   | 'types'
   | 'statuses';
 
-async function fetchTracInfo(type: TracInfoType): Promise<string[]> {
+async function fetchTracInfo(instance: TracInstance, type: TracInfoType): Promise<string[]> {
   if (type === 'components' || type === 'severities') {
-    return fetchTracFieldOptions(type === 'components' ? 'component' : 'severity');
+    return fetchTracFieldOptions(instance, type === 'components' ? 'component' : 'severity');
   }
 
   const fieldByType = {
@@ -900,19 +1005,19 @@ async function fetchTracInfo(type: TracInfoType): Promise<string[]> {
     statuses: 'status',
   } as const;
   const field = fieldByType[type];
-  const queryUrl = new URL('https://core.trac.wordpress.org/query');
+  const queryUrl = new URL(`${instance.origin}/query`);
   queryUrl.searchParams.set('format', 'csv');
   queryUrl.searchParams.set('max', '1000');
   addColumns(queryUrl, [field]);
 
-  const values = (await fetchCsvRecords(queryUrl))
+  const values = (await fetchCsvRecords(instance, queryUrl))
     .map((record) => record[field]?.trim() ?? '')
     .filter(Boolean);
   return Array.from(new Set(values)).sort();
 }
 
-async function fetchTimeline(days: number, limit: number) {
-  const timelineUrl = new URL('https://core.trac.wordpress.org/timeline');
+async function fetchTimeline(instance: TracInstance, days: number, limit: number) {
+  const timelineUrl = new URL(`${instance.origin}/timeline`);
   timelineUrl.searchParams.set('from', new Date().toISOString().slice(0, 10));
   timelineUrl.searchParams.set('daysback', days.toString());
   timelineUrl.searchParams.set('max', limit.toString());
@@ -921,7 +1026,7 @@ async function fetchTimeline(days: number, limit: number) {
   timelineUrl.searchParams.set('ticket_details', 'on');
   timelineUrl.searchParams.set('repo-', 'on');
 
-  const response = await fetchTrac(timelineUrl, {
+  const response = await fetchTrac(instance, timelineUrl, {
     headers: { 'User-Agent': TRAC_USER_AGENT },
   });
   if (!response.ok) {
@@ -960,12 +1065,16 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unknown error';
 }
 
-async function executeStandardTool(name: string, input: unknown): Promise<unknown> {
+async function executeStandardTool(
+  instance: TracInstance,
+  name: string,
+  input: unknown
+): Promise<unknown> {
   switch (name) {
     case 'searchTickets': {
       const { query, limit, page, status, component, milestone, resolution } =
         SearchTicketsArgsSchema.parse(input ?? {});
-      const search = await searchTracTickets(query, limit, page, {
+      const search = await searchTracTickets(instance, query, limit, page, {
         status,
         component,
         milestone,
@@ -976,7 +1085,7 @@ async function executeStandardTool(name: string, input: unknown): Promise<unknow
           id: ticket.id,
           title: ticket.summary,
           text: `#${ticket.id}: ${ticket.summary}\nStatus: ${ticket.status || 'unknown'}\nOwner: ${ticket.owner || 'unassigned'}\nType: ${ticket.type || 'unknown'}\nPriority: ${ticket.priority || 'unknown'}\nMilestone: ${ticket.milestone || 'none'}\nComponent: ${ticket.component || 'unknown'}`,
-          url: `https://core.trac.wordpress.org/ticket/${ticket.id}`,
+          url: `${instance.origin}/ticket/${ticket.id}`,
           metadata: {
             status: ticket.status,
             owner: ticket.owner,
@@ -998,35 +1107,43 @@ async function executeStandardTool(name: string, input: unknown): Promise<unknow
     case 'getTicket': {
       const { id, includeComments, commentLimit } = GetTicketArgsSchema.parse(input);
       return formatTicketResult(
-        await fetchTicket(id, includeComments, commentLimit),
+        instance,
+        await fetchTicket(instance, id, includeComments, commentLimit),
         includeComments
       );
     }
 
     case 'getChangeset': {
       const { revision, includeDiff, diffLimit } = GetChangesetArgsSchema.parse(input);
-      return formatChangesetResult(await fetchChangeset(revision, includeDiff, diffLimit));
+      return formatChangesetResult(
+        instance,
+        await fetchChangeset(instance, revision, includeDiff, diffLimit)
+      );
     }
 
     case 'getTimeline': {
       const { days, limit } = GetTimelineArgsSchema.parse(input ?? {});
-      const events = await fetchTimeline(days, limit);
+      const events = await fetchTimeline(instance, days, limit);
       return {
         results: events,
         totalEvents: events.length,
         daysBack: days,
-        timelineUrl: 'https://core.trac.wordpress.org/timeline',
+        timelineUrl: `${instance.origin}/timeline`,
       };
     }
 
     case 'getTracInfo': {
       const { type } = GetTracInfoArgsSchema.parse(input);
-      const data = await fetchTracInfo(type);
+      const data = await fetchTracInfo(instance, type);
+      const tracName = tracDisplayName(instance);
+      const heading = type.charAt(0).toUpperCase() + type.slice(1);
       return {
         id: type,
-        title: `WordPress Trac ${type}`,
-        text: `${type.charAt(0).toUpperCase() + type.slice(1)} available in WordPress Trac:\n\n${data.join('\n')}`,
-        url: 'https://core.trac.wordpress.org/',
+        title: `${tracName} ${type}`,
+        text: data.length
+          ? `${heading} available in ${tracName}:\n\n${data.join('\n')}`
+          : `${heading} are not available in ${tracName}.`,
+        url: `${instance.origin}/`,
         metadata: { type, data, total: data.length },
       };
     }
@@ -1039,7 +1156,7 @@ async function executeStandardTool(name: string, input: unknown): Promise<unknow
 /**
  * Handle MCP JSON-RPC 2.0 requests
  */
-export async function handleMcpRequest(request: JsonRpcRequest) {
+export async function handleMcpRequest(instance: TracInstance, request: JsonRpcRequest) {
   const { method, params, id } = request;
   if (id === undefined) {
     return null;
@@ -1053,7 +1170,7 @@ export async function handleMcpRequest(request: JsonRpcRequest) {
           tools: {},
         },
         serverInfo: {
-          name: 'WordPress Trac',
+          name: tracDisplayName(instance),
           version: '1.0.0',
         },
       });
@@ -1214,7 +1331,10 @@ export async function handleMcpRequest(request: JsonRpcRequest) {
       }
 
       try {
-        return toolResult(id, await executeStandardTool(parsed.data.name, parsed.data.arguments));
+        return toolResult(
+          id,
+          await executeStandardTool(instance, parsed.data.name, parsed.data.arguments)
+        );
       } catch (error) {
         if (error instanceof UnknownToolError || error instanceof z.ZodError) {
           return jsonRpcError(id, -32602, errorMessage(error));
@@ -1232,7 +1352,7 @@ export async function handleMcpRequest(request: JsonRpcRequest) {
  * Handle ChatGPT-specific MCP JSON-RPC 2.0 requests
  * Provides the search and fetch compatibility tools.
  */
-export async function handleChatGPTMcpRequest(request: JsonRpcRequest) {
+export async function handleChatGPTMcpRequest(instance: TracInstance, request: JsonRpcRequest) {
   const { method, params, id } = request;
   if (id === undefined) {
     return null;
@@ -1246,7 +1366,7 @@ export async function handleChatGPTMcpRequest(request: JsonRpcRequest) {
           tools: {},
         },
         serverInfo: {
-          name: 'WordPress Trac',
+          name: tracDisplayName(instance),
           version: '1.0.0',
         },
       });
@@ -1309,7 +1429,10 @@ Query Types:
       }
 
       try {
-        return toolResult(id, await executeChatGptTool(parsed.data.name, parsed.data.arguments));
+        return toolResult(
+          id,
+          await executeChatGptTool(instance, parsed.data.name, parsed.data.arguments)
+        );
       } catch (error) {
         if (error instanceof UnknownToolError || error instanceof z.ZodError) {
           return jsonRpcError(id, -32602, errorMessage(error));
@@ -1323,75 +1446,104 @@ Query Types:
   }
 }
 
-async function searchTicketsForChatGPT(query: string, limit: number) {
-  const search = await searchTracTickets(query, limit, 1);
+async function searchTicketsForChatGPT(instance: TracInstance, query: string, limit: number) {
+  const search = await searchTracTickets(instance, query, limit, 1);
   return {
     results: search.tickets.map((ticket) => ({
       id: ticket.id.toString(),
       title: `#${ticket.id}: ${ticket.summary}`,
       text: `Ticket #${ticket.id}: ${ticket.summary}\nStatus: ${ticket.status}\nType: ${ticket.type}\nPriority: ${ticket.priority}\nOwner: ${ticket.owner}\nMilestone: ${ticket.milestone}`,
-      url: `https://core.trac.wordpress.org/ticket/${ticket.id}`,
+      url: `${instance.origin}/ticket/${ticket.id}`,
       metadata: { ticket },
     })),
     totalFound: search.totalFound,
   };
 }
 
-async function getTicketForChatGPT(ticketId: number, includeComments: boolean) {
-  const ticketData = await fetchTicket(ticketId, includeComments);
-  return formatTicketResult(ticketData, includeComments, true);
+async function getTicketForChatGPT(
+  instance: TracInstance,
+  ticketId: number,
+  includeComments: boolean
+) {
+  const ticketData = await fetchTicket(instance, ticketId, includeComments);
+  return formatTicketResult(instance, ticketData, includeComments, true);
 }
 
-async function getChangesetForChatGPT(revision: number, includeDiff: boolean) {
-  const changeset = await fetchChangeset(revision, includeDiff);
-  return formatChangesetResult(changeset, true);
+async function getChangesetForChatGPT(
+  instance: TracInstance,
+  revision: number,
+  includeDiff: boolean
+) {
+  const changeset = await fetchChangeset(instance, revision, includeDiff);
+  return formatChangesetResult(instance, changeset, true);
 }
 
-async function getTimelineForChatGPT(days: number, limit: number) {
-  return { results: await fetchTimeline(days, limit) };
+async function getTimelineForChatGPT(instance: TracInstance, days: number, limit: number) {
+  return { results: await fetchTimeline(instance, days, limit) };
 }
 
-async function runChatGptSearch(query: string) {
+async function runChatGptSearch(instance: TracInstance, query: string) {
   const trimmed = query.trim();
+
+  /*
+   * A direct lookup that misses is an empty result rather than an error, but an
+   * instance that does not exist is a broken connection the caller must see.
+   */
+  const emptyResultForMiss = (error: unknown) => {
+    if (error instanceof UnknownTracInstanceError) {
+      throw error;
+    }
+    return { results: [], query, totalFound: 0 };
+  };
+
   if (/^#?\d+$/.test(trimmed)) {
     try {
       const ticket = await getTicketForChatGPT(
+        instance,
         Number.parseInt(trimmed.replace('#', ''), 10),
         false
       );
       return { results: [ticket], query, totalFound: 1 };
-    } catch {
-      return { results: [], query, totalFound: 0 };
+    } catch (error) {
+      return emptyResultForMiss(error);
     }
   }
   if (/^r\d+$/i.test(trimmed)) {
     try {
-      const changeset = await getChangesetForChatGPT(Number.parseInt(trimmed.slice(1), 10), false);
+      const changeset = await getChangesetForChatGPT(
+        instance,
+        Number.parseInt(trimmed.slice(1), 10),
+        false
+      );
       return { results: [changeset], query, totalFound: 1 };
-    } catch {
-      return { results: [], query, totalFound: 0 };
+    } catch (error) {
+      return emptyResultForMiss(error);
     }
   }
   if (/\b(recent|timeline|latest|activity)\b/i.test(trimmed)) {
-    const timeline = await getTimelineForChatGPT(7, 20);
+    const timeline = await getTimelineForChatGPT(instance, 7, 20);
     return { results: timeline.results, query, totalFound: timeline.results.length };
   }
 
-  const tickets = await searchTicketsForChatGPT(query, 10);
+  const tickets = await searchTicketsForChatGPT(instance, query, 10);
   return { results: tickets.results, query, totalFound: tickets.totalFound };
 }
 
-async function executeChatGptTool(name: string, input: unknown): Promise<unknown> {
+async function executeChatGptTool(
+  instance: TracInstance,
+  name: string,
+  input: unknown
+): Promise<unknown> {
   switch (name) {
     case 'search': {
       const { query } = ChatGptSearchArgsSchema.parse(input);
-      return runChatGptSearch(query);
+      return runChatGptSearch(instance, query);
     }
     case 'fetch': {
       const { id } = ChatGptFetchArgsSchema.parse(input);
       return id.startsWith('r')
-        ? getChangesetForChatGPT(Number.parseInt(id.slice(1), 10), true)
-        : getTicketForChatGPT(Number.parseInt(id, 10), true);
+        ? getChangesetForChatGPT(instance, Number.parseInt(id.slice(1), 10), true)
+        : getTicketForChatGPT(instance, Number.parseInt(id, 10), true);
     }
     default:
       throw new UnknownToolError(`Unknown tool: ${name}`);
@@ -1525,6 +1677,25 @@ function getLandingPage(url: URL, versionInfo?: { id: string; tag?: string; time
       text-decoration: underline;
     }
 
+    .instances {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+      font-size: 0.95rem;
+    }
+
+    .instances th,
+    .instances td {
+      text-align: left;
+      padding: 0.5rem 0.75rem 0.5rem 0;
+      border-bottom: 1px solid #e1e4e8;
+    }
+
+    .instances th {
+      color: #666;
+      font-weight: 600;
+    }
+
     .contribute {
       margin-top: 2rem;
       padding: 1.5rem;
@@ -1587,8 +1758,26 @@ function getLandingPage(url: URL, versionInfo?: { id: string; tag?: string; time
     <code>fetch</code> - Get detailed information about specific items
   </div>
   
+  <h2>Trac Instances</h2>
+  <p>Each WordPress.org Trac gets its own endpoint. Connect to the one you need; connect to several to use more than one.</p>
+  <table class="instances">
+    <thead>
+      <tr><th>Trac</th><th>Endpoint</th></tr>
+    </thead>
+    <tbody>
+${Object.keys(TRAC_LABELS)
+  .map((slug) => {
+    const instance = makeTracInstance(slug);
+    const endpoint = slug === 'core' ? '/mcp' : `/mcp/${slug}`;
+    return `      <tr><td><a href="${instance.origin}/">${instance.label}</a></td><td><code>${url.origin}${endpoint}</code></td></tr>`;
+  })
+  .join('\n')}
+    </tbody>
+  </table>
+  <p>Any other <code>&lt;slug&gt;.trac.wordpress.org</code> works the same way at <code>${url.origin}/mcp/&lt;slug&gt;</code>. Fields vary between instances: a Trac without severities or components reports them as unavailable rather than failing.</p>
+
   <h2>Configuration</h2>
-  
+
   <h3>Standard MCP (Claude Desktop, etc.)</h3>
   <div class="code-block">
     <code>{
@@ -1596,6 +1785,10 @@ function getLandingPage(url: URL, versionInfo?: { id: string; tag?: string; time
     "wordpress-trac": {
       "command": "npx",
       "args": ["mcp-remote", "${url.origin}/mcp"]
+    },
+    "wordpress-meta-trac": {
+      "command": "npx",
+      "args": ["mcp-remote", "${url.origin}/mcp/meta"]
     }
   }
 }</code>
@@ -1610,6 +1803,7 @@ function getLandingPage(url: URL, versionInfo?: { id: string; tag?: string; time
 3. Enable in Composer → Deep Research tool
 4. Add as research source if needed</code>
   </div>
+  <p>Other instances use <code>${url.origin}/mcp/&lt;slug&gt;/chatgpt</code>.</p>
   <p>See: <a href="https://platform.openai.com/docs/mcp#connect-in-chatgpt">ChatGPT MCP Documentation</a></p>
 
   <section class="contribute">
@@ -1651,7 +1845,40 @@ const MCP_CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type, MCP-Protocol-Version',
 };
 
-async function handleMcpHttpRequest(request: Request, chatGpt: boolean): Promise<Response> {
+type McpRoute = {
+  instance: TracInstance;
+  chatGpt: boolean;
+};
+
+/**
+ * Resolve an MCP endpoint path to the Trac instance and tool set it addresses.
+ *
+ * Recognises /mcp, /mcp/chatgpt, /mcp/<slug>, and /mcp/<slug>/chatgpt, where the
+ * two slugless paths address core.
+ *
+ * @param pathname Request path.
+ * @return The matched route, or null when the path is not an MCP endpoint.
+ */
+export function matchMcpRoute(pathname: string): McpRoute | null {
+  const segments = pathname.split('/');
+  if (segments[1] !== 'mcp' || segments.length > 4) {
+    return null;
+  }
+  if (segments.length === 2) {
+    return { instance: CORE_TRAC, chatGpt: false };
+  }
+  if (segments.length === 3 && segments[2] === 'chatgpt') {
+    return { instance: CORE_TRAC, chatGpt: true };
+  }
+  if (segments.length === 4 && segments[3] !== 'chatgpt') {
+    return null;
+  }
+
+  const instance = tracInstance(segments[2] ?? '');
+  return instance ? { instance, chatGpt: segments.length === 4 } : null;
+}
+
+async function handleMcpHttpRequest(route: McpRoute, request: Request): Promise<Response> {
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: MCP_CORS_HEADERS });
   }
@@ -1680,9 +1907,9 @@ async function handleMcpHttpRequest(request: Request, chatGpt: boolean): Promise
     });
   }
 
-  const response = chatGpt
-    ? await handleChatGPTMcpRequest(parsed.data)
-    : await handleMcpRequest(parsed.data);
+  const response = route.chatGpt
+    ? await handleChatGPTMcpRequest(route.instance, parsed.data)
+    : await handleMcpRequest(route.instance, parsed.data);
   if (response === null) {
     return new Response(null, { status: 202, headers: MCP_CORS_HEADERS });
   }
@@ -1787,8 +2014,18 @@ export default {
     }
 
     // Handle MCP endpoints
-    if (url.pathname === '/mcp' || url.pathname === '/mcp/chatgpt') {
-      return handleMcpHttpRequest(request, url.pathname === '/mcp/chatgpt');
+    const mcpRoute = matchMcpRoute(url.pathname);
+    if (mcpRoute) {
+      return handleMcpHttpRequest(mcpRoute, request);
+    }
+
+    /*
+     * Answer the whole /mcp namespace here so an unroutable instance returns 404
+     * to every method, rather than letting a preflight fall through to the
+     * catch-all below and succeed for a path that cannot serve the request.
+     */
+    if (url.pathname.startsWith('/mcp/')) {
+      return new Response('Not found', { status: 404, headers: MCP_CORS_HEADERS });
     }
 
     // Handle CORS preflight

--- a/src/index.ts
+++ b/src/index.ts
@@ -2145,11 +2145,7 @@ export default {
       return handleMcpHttpRequest(mcpRoute, request);
     }
 
-    /*
-     * Answer the whole /mcp namespace here so an unroutable instance returns 404
-     * to every method, rather than letting a preflight fall through to the
-     * catch-all below and succeed for a path that cannot serve the request.
-     */
+    // Own the whole /mcp namespace, so a preflight cannot succeed on a path that then 404s.
     if (url.pathname.startsWith('/mcp/')) {
       return new Response('Not found', { status: 404, headers: MCP_CORS_HEADERS });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -711,11 +711,7 @@ async function fetchLinkedPullRequests(
   pullRequestsUrl.searchParams.set('trac', instance.slug);
   pullRequestsUrl.searchParams.set('ticket', ticketId.toString());
 
-  /*
-   * Redirects are followed here. This is one fixed host rather than a wildcard
-   * domain, so a redirect means it moved, and refusing to follow would turn
-   * that into every ticket silently reporting no linked pull requests.
-   */
+  // One fixed host rather than a wildcard domain, so a redirect means it moved: follow it.
   const response = await fetch(pullRequestsUrl.toString(), {
     headers: {
       'User-Agent': TRAC_USER_AGENT,
@@ -793,11 +789,7 @@ export async function searchTracTickets(
   const tickets = records.map(ticketFromRecord);
   const filterFields = ticketFilterFields(queryUrl);
   if (!totalResponse.ok) {
-    /*
-     * The count page carries the field list, so without it a filter cannot be
-     * told from one Trac dropped. Returning the rows anyway would present an
-     * unfiltered set as a filtered one, so a filtered search fails here.
-     */
+    // Without the field list, a filter Trac dropped cannot be told from one it applied.
     if (filterFields.length) {
       throw new Error(
         `Cannot confirm the ${filterFields.join(' and ')} filter against ${tracDisplayName(instance)} because its query page returned HTTP ${totalResponse.status}. Trac ignores a filter on a field it does not configure, so these results could be the whole ticket list.`

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,12 @@ export type TracInstance = {
   label: string;
 };
 
+/**
+ * Build an instance from a slug that has already been validated.
+ *
+ * @param slug Subdomain label of a *.trac.wordpress.org instance.
+ * @return The instance.
+ */
 function makeTracInstance(slug: string): TracInstance {
   return {
     slug,
@@ -187,10 +193,15 @@ async function isTransientTracResponse(response: Response): Promise<boolean> {
   return /Checking your browser/i.test(await response.clone().text());
 }
 
-/*
+/**
+ * Whether a response is a redirect that must not be followed.
+ *
  * The status range is what `redirect: 'manual'` produces. `redirected` cannot be
  * true alongside it and is kept as a backstop: a runtime that ignored the option
  * would hand back another instance's page, which is the one thing never to return.
+ *
+ * @param response Response to a request that asked not to follow redirects.
+ * @return True when the response redirects.
  */
 function isRedirect(response: Response): boolean {
   return response.redirected || (response.status >= 300 && response.status < 400);
@@ -593,6 +604,12 @@ function configuredTracFields(html: string): Set<string> | null {
 // Query parameters this server sets for itself; everything else it adds is a filter.
 const QUERY_CONTROL_PARAMS = new Set(['col', 'format', 'max', 'page']);
 
+/**
+ * Ticket fields a query URL filters on.
+ *
+ * @param url A Trac query URL this server built.
+ * @return The field names filtered on, without the parameters that shape the response.
+ */
 function ticketFilterFields(url: URL): string[] {
   return Array.from(new Set(url.searchParams.keys())).filter(
     (name) => !QUERY_CONTROL_PARAMS.has(name)

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,11 @@ async function isTransientTracResponse(response: Response): Promise<boolean> {
   return /Checking your browser/i.test(await response.clone().text());
 }
 
+/*
+ * The status range is what `redirect: 'manual'` produces. `redirected` cannot be
+ * true alongside it and is kept as a backstop: a runtime that ignored the option
+ * would hand back another instance's page, which is the one thing never to return.
+ */
 function isRedirect(response: Response): boolean {
   return response.redirected || (response.status >= 300 && response.status < 400);
 }
@@ -689,16 +694,17 @@ async function fetchLinkedPullRequests(
   pullRequestsUrl.searchParams.set('trac', instance.slug);
   pullRequestsUrl.searchParams.set('ticket', ticketId.toString());
 
+  /*
+   * Redirects are followed here. This is one fixed host rather than a wildcard
+   * domain, so a redirect means it moved, and refusing to follow would turn
+   * that into every ticket silently reporting no linked pull requests.
+   */
   const response = await fetch(pullRequestsUrl.toString(), {
     headers: {
       'User-Agent': TRAC_USER_AGENT,
       Accept: 'application/json',
     },
-    redirect: 'manual',
   });
-  if (isRedirect(response)) {
-    throw new Error('Failed to fetch linked pull requests: unexpected redirect');
-  }
   if (!response.ok) {
     throw new Error(`Failed to fetch linked pull requests: ${response.statusText}`);
   }
@@ -768,7 +774,19 @@ export async function searchTracTickets(
     fetchTrac(instance, totalUrl, { headers: { 'User-Agent': TRAC_USER_AGENT } }),
   ]);
   const tickets = records.map(ticketFromRecord);
+  const filterFields = ticketFilterFields(queryUrl);
   if (!totalResponse.ok) {
+    /*
+     * The count page carries the field list, so without it a filter cannot be
+     * told from one Trac dropped. Returning the rows anyway would present an
+     * unfiltered set as a filtered one, so a filtered search fails here.
+     */
+    if (filterFields.length) {
+      throw new Error(
+        `Cannot confirm the ${filterFields.join(' and ')} filter against ${tracDisplayName(instance)} because its query page returned HTTP ${totalResponse.status}. Trac ignores a filter on a field it does not configure, so these results could be the whole ticket list.`
+      );
+    }
+
     return {
       tickets,
       totalFound: (pageNumber - 1) * pageSize + tickets.length,
@@ -784,7 +802,7 @@ export async function searchTracTickets(
   // The count page is a query page, so it carries the field list this filter has to exist in.
   const configured = configuredTracFields(totalHtml);
   if (configured) {
-    const unsupported = ticketFilterFields(queryUrl).filter((field) => !configured.has(field));
+    const unsupported = filterFields.filter((field) => !configured.has(field));
     if (unsupported.length) {
       throw new Error(
         `${tracDisplayName(instance)} has no ${unsupported.join(' or ')} field, so filtering on it would return every ticket. Fields available here: ${Array.from(configured).sort().join(', ')}`
@@ -1038,7 +1056,7 @@ ${changeset.diff ? `Diff:\n${changeset.diff}` : 'No diff available'}`,
 async function fetchTracFieldOptions(
   instance: TracInstance,
   field: 'component' | 'severity'
-): Promise<string[]> {
+): Promise<TracInfoResult> {
   const queryUrl = new URL(`${instance.origin}/query`);
   queryUrl.searchParams.set(field, '');
   const response = await fetchTrac(instance, queryUrl, {
@@ -1055,7 +1073,7 @@ async function fetchTracFieldOptions(
     throw new Error(`Trac did not return ${field} options`);
   }
   if (!configured.has(field)) {
-    return [];
+    return { data: [], configured: false };
   }
 
   // The field exists here, so a missing option list is a parse failure rather than an answer.
@@ -1066,9 +1084,12 @@ async function fetchTracFieldOptions(
     throw new Error(`Trac did not return ${field} options`);
   }
 
-  return Array.from(select.matchAll(/<option[^>]*value="([^"]+)"[^>]*>/gi), (match) =>
-    cleanTracText(match[1] ?? '')
-  ).filter(Boolean);
+  return {
+    data: Array.from(select.matchAll(/<option[^>]*value="([^"]+)"[^>]*>/gi), (match) =>
+      cleanTracText(match[1] ?? '')
+    ).filter(Boolean),
+    configured: true,
+  };
 }
 
 type TracInfoType =
@@ -1079,7 +1100,14 @@ type TracInfoType =
   | 'types'
   | 'statuses';
 
-async function fetchTracInfo(instance: TracInstance, type: TracInfoType): Promise<string[]> {
+/*
+ * Whether the instance configures the field at all, which only the picker-backed
+ * types can answer. The rest read values off tickets, where an empty result means
+ * no ticket carried one rather than no such field.
+ */
+type TracInfoResult = { data: string[]; configured: boolean };
+
+async function fetchTracInfo(instance: TracInstance, type: TracInfoType): Promise<TracInfoResult> {
   if (type === 'components' || type === 'severities') {
     return fetchTracFieldOptions(instance, type === 'components' ? 'component' : 'severity');
   }
@@ -1099,7 +1127,7 @@ async function fetchTracInfo(instance: TracInstance, type: TracInfoType): Promis
   const values = (await fetchCsvRecords(instance, queryUrl))
     .map((record) => record[field]?.trim() ?? '')
     .filter(Boolean);
-  return Array.from(new Set(values)).sort();
+  return { data: Array.from(new Set(values)).sort(), configured: true };
 }
 
 async function fetchTimeline(instance: TracInstance, days: number, limit: number) {
@@ -1220,15 +1248,18 @@ async function executeStandardTool(
 
     case 'getTracInfo': {
       const { type } = GetTracInfoArgsSchema.parse(input);
-      const data = await fetchTracInfo(instance, type);
+      const { data, configured } = await fetchTracInfo(instance, type);
       const tracName = tracDisplayName(instance);
       const heading = type.charAt(0).toUpperCase() + type.slice(1);
+      const emptyText = configured
+        ? `No ${type} found in ${tracName}.`
+        : `${heading} are not available in ${tracName}.`;
       return {
         id: type,
         title: `${tracName} ${type}`,
         text: data.length
           ? `${heading} available in ${tracName}:\n\n${data.join('\n')}`
-          : `${heading} are not available in ${tracName}.`,
+          : emptyText,
         url: `${instance.origin}/`,
         metadata: { type, data, total: data.length },
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,42 @@ function isRedirect(response: Response): boolean {
   return response.redirected || (response.status >= 300 && response.status < 400);
 }
 
+/**
+ * Origin a redirect response points at.
+ *
+ * @param response A redirect response.
+ * @param requestUrl URL the response answers, used to resolve a relative target.
+ * @return The target origin, or null when there is no usable Location header.
+ */
+function redirectOrigin(response: Response, requestUrl: URL): string | null {
+  const location = response.headers.get('location');
+  if (!location) {
+    return null;
+  }
+
+  try {
+    return new URL(location, requestUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Failure to report for a redirect, which is never followed.
+ *
+ * @param instance Instance the request addressed.
+ * @param response The redirect response.
+ * @param requestUrl URL the response answers.
+ * @return The error to throw.
+ */
+function redirectError(instance: TracInstance, response: Response, requestUrl: URL): Error {
+  // A slug with no Trac behind it redirects off-origin; one that stays put is something else.
+  const target = redirectOrigin(response, requestUrl);
+  return target && target !== instance.origin
+    ? new UnknownTracInstanceError(`Unknown or unavailable Trac instance: ${instance.slug}`)
+    : new Error(`Unexpected redirect from ${instance.origin}: HTTP ${response.status}`);
+}
+
 export async function fetchTrac(
   instance: TracInstance,
   input: string | URL,
@@ -205,7 +241,7 @@ export async function fetchTrac(
   for (let attempt = 0; ; attempt++) {
     let response: Response;
     try {
-      // Unknown subdomains redirect to core, so following one would answer with another instance's data.
+      // Never follow a redirect: unknown subdomains point at core, whose data is not ours to return.
       response = await fetch(url.toString(), { ...init, redirect: 'manual' });
     } catch (error) {
       if (attempt >= retryDelays.length) {
@@ -216,7 +252,7 @@ export async function fetchTrac(
     }
 
     if (isRedirect(response)) {
-      throw new UnknownTracInstanceError(`Unknown or unavailable Trac instance: ${instance.slug}`);
+      throw redirectError(instance, response, url);
     }
     if (!(await isTransientTracResponse(response)) || attempt >= retryDelays.length) {
       return response;
@@ -525,6 +561,39 @@ export function parseCsvRecords(csvData: string): TracRecord[] {
   });
 }
 
+/**
+ * Ticket fields an instance configures, read from the filter picker on a query page.
+ *
+ * Instances differ: themes has no component, and only some have severity. Trac
+ * drops a filter on a field it does not configure instead of rejecting it, so
+ * this list is what separates an unsupported filter from a matching one.
+ *
+ * @param html A Trac query page.
+ * @return The configured field names, or null when the page is not a query page.
+ */
+function configuredTracFields(html: string): Set<string> | null {
+  const picker = html.match(/<select[^>]*\bname="add_filter_0"[^>]*>([\s\S]*?)<\/select>/i)?.[1];
+  if (picker === undefined) {
+    return null;
+  }
+
+  return new Set(
+    Array.from(
+      picker.matchAll(/<option[^>]*\bvalue="([^"]+)"/gi),
+      (match) => match[1] ?? ''
+    ).filter(Boolean)
+  );
+}
+
+// Query parameters this server sets for itself; everything else it adds is a filter.
+const QUERY_CONTROL_PARAMS = new Set(['col', 'format', 'max', 'page']);
+
+function ticketFilterFields(url: URL): string[] {
+  return Array.from(new Set(url.searchParams.keys())).filter(
+    (name) => !QUERY_CONTROL_PARAMS.has(name)
+  );
+}
+
 function addColumns(url: URL, columns: readonly string[]): void {
   for (const column of columns) {
     url.searchParams.append('col', column);
@@ -711,6 +780,18 @@ export async function searchTracTickets(
   }
 
   const totalHtml = await totalResponse.text();
+
+  // The count page is a query page, so it carries the field list this filter has to exist in.
+  const configured = configuredTracFields(totalHtml);
+  if (configured) {
+    const unsupported = ticketFilterFields(queryUrl).filter((field) => !configured.has(field));
+    if (unsupported.length) {
+      throw new Error(
+        `${tracDisplayName(instance)} has no ${unsupported.join(' or ')} field, so filtering on it would return every ticket. Fields available here: ${Array.from(configured).sort().join(', ')}`
+      );
+    }
+  }
+
   const totalMatch = totalHtml.match(/<span class="numrows">\s*\(([\d,]+)\s+match(?:es)?\)/i);
   if (!totalMatch?.[1]) {
     throw new Error('Trac did not return the total ticket count');
@@ -969,15 +1050,20 @@ async function fetchTracFieldOptions(
   }
 
   const html = await response.text();
+  const configured = configuredTracFields(html);
+  if (!configured) {
+    throw new Error(`Trac did not return ${field} options`);
+  }
+  if (!configured.has(field)) {
+    return [];
+  }
+
+  // The field exists here, so a missing option list is a parse failure rather than an answer.
   const select = html.match(
-    new RegExp(`<select\\s+name="0_${field}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i')
+    new RegExp(`<select[^>]*\\bname="0_${field}"[^>]*>([\\s\\S]*?)<\\/select>`, 'i')
   )?.[1];
   if (!select) {
-    // The filter picker renders on every query page, so its absence means this is not one.
-    if (!/<select\s+name="add_filter_0"/i.test(html)) {
-      throw new Error(`Trac did not return ${field} options`);
-    }
-    return [];
+    throw new Error(`Trac did not return ${field} options`);
   }
 
   return Array.from(select.matchAll(/<option[^>]*value="([^"]+)"[^>]*>/gi), (match) =>


### PR DESCRIPTION
Extends the server from Core Trac to every WordPress.org Trac. Meta and Plugins were the motivating cases; the mechanism covers all of them.

## How an instance is selected

Every WordPress.org Trac lives at `<slug>.trac.wordpress.org` and speaks the same dialect, so an instance is described entirely by its slug. One is resolved per request from the endpoint path and threaded through the fetch and format layers in place of the hardcoded Core origin.

```
/mcp                 Core, standard tools
/mcp/chatgpt         Core, compatibility tools
/mcp/<slug>          that instance, standard tools
/mcp/<slug>/chatgpt  that instance, compatibility tools
```

The instance binds to the connection rather than to a tool argument. That means no advertised or runtime schema changes, and a client cannot read the wrong Trac by mistake — which matters because ticket `#5483` exists on both Core and Meta and means different things on each. `chatgpt` is reserved as a route keyword so `/mcp/chatgpt` keeps its meaning.

Any well-formed slug resolves, so a Trac added later needs no code change. The README table is a discovery aid, not an allowlist.

## Backward compatibility

`/mcp` and `/mcp/chatgpt` return byte-identical responses across `initialize`, `tools/list`, `ping`, and every `tools/call` result. URLs in tool output are built from the resolved origin, which for Core is the same literal string as before. Pinned by tests rather than assumed.

Paths that 404 today still 404. Module-level exports (`fetchTrac`, `searchTracTickets`, both `handle*McpRequest`) gain an `instance` parameter; only the test suite imports them.

## Redirects are not followed

`*.trac.wordpress.org` has wildcard DNS, and **every unknown subdomain 301s to Core and returns 200 with Core's data**. A server that follows redirects answers `/mcp/xyzzy` with Core tickets and looks entirely healthy.

`fetchTrac` therefore sends `redirect: 'manual'` and treats any 3xx as proof the instance does not exist. I verified against the live site that no endpoint this server uses redirects, including the error paths (missing ticket, missing changeset, empty result set, page past the end, filtered query, unknown column).

The resulting error has its own type so that `search`'s "direct lookup missed" handling cannot swallow it — without that, `search {"query":"65739"}` on a dead instance returned a cheerful empty result.

## Fields differ between instances

Themes has no components; only some instances have severities; `focuses` is Core-only. Trac silently drops unknown `col=` parameters, so ticket parsing needed nothing. `getTracInfo` now reports a field the instance does not configure as unavailable rather than failing, while still failing when the page is not a Trac query page at all — the filter picker, which renders on every query page, separates the two.

## Verification

`pnpm check` passes: 55 tests, TypeScript, Biome, both Worker dry-run builds.

Automated tests mock Trac, so they cannot see the redirect trap. The full smoke test was also run live against `pnpm dev`:

- Core `initialize` byte-identical on both slugless endpoints
- All eight documented instances return real data end to end
- `/mcp/xyzzy-nope` → `Unknown or unavailable Trac instance`, not Core's data
- `/mcp/meta getTracInfo severities` → unavailable, `total: 0`, not an error; Core still lists all six
- `/mcp/`, `/mcp/Meta`, `/mcp/meta/`, `/mcp/meta/tools`, `/mcp/chatgpt/chatgpt` → 404
- Core regressions intact: ticket 65793 attachment URL, changeset 58504 diff truncation, `/mcp/chatgpt fetch r58504`

`docs/smoke-test.md` gains a section 7 covering all of the above, and `AGENTS.md` records the widened trust boundary: upstream requests may reach `*.trac.wordpress.org` only via a slug validated against a strict pattern, with every URL rechecked against the resolved origin and redirects never followed.

## Note for the maintainer

`server.json` is untouched. Its `title` is `WordPress Core Trac` and its single remote is `/mcp`, both still accurate, but it is the published MCP-registry identity and renaming it is a call for you rather than me.

Draft because this widens a documented trust boundary and I would like that reviewed before it ships. Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)