### PR TITLE
Name the registry entry WordPress Trac

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.WordPress/trac-mcp",
-  "title": "WordPress Core Trac",
-  "description": "Read-only Model Context Protocol server for WordPress Core Trac",
+  "title": "WordPress Trac",
+  "description": "Read-only Model Context Protocol server for WordPress Trac",
   "version": "1.0.0",
   "websiteUrl": "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/",
   "repository": {


### PR DESCRIPTION
The server has reported `serverInfo.name` as `WordPress Trac` since it shipped (`src/index.ts:1056`), while the published registry entry called it `WordPress Core Trac`. This drops `Core` from the title and description so the registry matches what the server says about itself.

- `title`: `WordPress Core Trac` → `WordPress Trac`
- `description`: same one-word change

`name` is the registry primary key and is deliberately unchanged — renaming it would orphan the existing entry rather than update it. `remotes` is unchanged too: one entry describes one endpoint, and `/mcp` is still the server's address.

Accurate today, and stays accurate as more Trac instances become reachable.

Not published. There is no publish workflow in this repository, so the registry entry only changes when a maintainer runs the publisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)