### PR TITLE
Bump to 1.1.0 and correct docs the multi-instance change left behind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Green CI does not mean the feature works: every automated test mocks Trac. Follo
 - Keep upstream requests on `*.trac.wordpress.org` and the official linked-PR endpoint at `api.wordpress.org/dotorg/trac/pr/`.
 - Take the Trac instance from the endpoint path, never from a tool argument. Binding it to the connection is what stops a client reading the wrong Trac.
 - Expect fields to differ between instances. Report a field an instance does not configure as unavailable rather than failing, but keep failing when the page is not a Trac query page at all.
-- Never let a filter reach Trac on a field the instance does not configure. Trac ignores it and returns the unfiltered result set, which is indistinguishable from a real answer. Check against the filter picker Trac renders on every query page, and treat that list as the authority for which fields exist.
+- Never return results for a filter on a field the instance does not configure. Trac ignores such a filter and returns the unfiltered result set, which is indistinguishable from a real answer. The query and the field check run together, so the guard discards the response rather than preventing the request. Check against the filter picker Trac renders on every query page, and treat that list as the authority for which fields exist.
 - Return upstream failures as MCP tool errors.
 - Update README and manual checks when behavior changes.
 - Do not deploy without explicit maintainer approval.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ pnpm run deploy:production
   pattern before it reaches a request, and every request is checked against the resolved origin.
 - Upstream redirects are never followed. `*.trac.wordpress.org` has wildcard DNS and redirects
   unknown subdomains to Core, so following one would answer for one instance with another's data.
-  A redirect is reported as an unknown instance instead.
+  A redirect that leaves the instance origin is reported as an unknown instance; one that stays on
+  it is reported as an upstream failure.
 - Transient transport failures, rate limits, server errors, and Trac bot challenges receive bounded
   retries. Permanent 403 and 404 responses return immediately.
 - Responses are parsed from public Trac pages and machine-readable formats.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,8 @@ Start the Worker by following [local-development.md](local-development.md), then
 8. Exercise a non-Core instance at `/mcp/meta` and `/mcp/meta/chatgpt`. Every URL in a result must point at `meta.trac.wordpress.org`; a `core.trac.wordpress.org` URL means the instance was not threaded through.
 9. Ask an instance for a field it does not configure, such as severities on `/mcp/meta`. Expect an "are not available" answer rather than a tool error, and confirm Core still returns its populated list.
 10. Call a tool on a slug with no Trac behind it, such as `/mcp/xyzzy-nope`. Expect `Unknown or unavailable Trac instance`. Core data here is a security regression: the domain redirects unknown subdomains to Core, so a server that follows redirects fails this check while looking healthy.
+11. Filter a search on a field the instance does not configure, such as a component on `/mcp/themes`. Expect a tool error naming the fields that instance does have, and confirm the same filter still succeeds where the field exists. A passing-looking result is the failure here: Trac answers an unconfigured filter with the whole ticket set and a matching count.
+12. Send a malformed instance path, such as `/mcp/`, `/mcp/Meta`, `/mcp/meta/`, `/mcp/meta/tools`, or `/mcp/chatgpt/chatgpt`. Each returns `404`. Slugs are lowercase, and `chatgpt` is a route keyword rather than an instance.
 
 Do not paste private ticket data or credentials into fixtures. If live checks fail, distinguish a Trac response change from Worker behavior before changing a parser.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wordpress-trac-mcp-server",
-  "version": "1.0.0",
-  "description": "Read-only Model Context Protocol server for WordPress Core Trac",
+  "version": "1.1.0",
+  "description": "Read-only Model Context Protocol server for WordPress Trac",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.WordPress/trac-mcp",
   "title": "WordPress Trac",
   "description": "Read-only Model Context Protocol server for WordPress Trac",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "websiteUrl": "https://wordpress-trac-mcp-server-prod.a8c-aiops.workers.dev/",
   "repository": {
     "url": "https://github.com/WordPress/trac-mcp",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -598,6 +598,25 @@ describe('Trac instance routing', () => {
     expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe('manual');
   });
 
+  /*
+   * A redirect only proves the instance is missing when it names a target off the
+   * instance origin. Without a usable Location there is nothing to compare, so the
+   * failure has to stay generic rather than claim the Trac does not exist.
+   */
+  it('reports a redirect with no Location header as an upstream failure', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 301 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const instance = tracInstance('xyzzy-nope');
+    if (!instance) {
+      throw new Error('A well-formed slug should resolve regardless of whether the Trac exists');
+    }
+
+    await expect(
+      fetchTrac(instance, 'https://xyzzy-nope.trac.wordpress.org/timeline', undefined, [0, 0])
+    ).rejects.toThrow('Unexpected redirect from https://xyzzy-nope.trac.wordpress.org: HTTP 301');
+  });
+
   it('serves core under its own name at both slugless endpoints', async () => {
     for (const path of ['/mcp', '/mcp/chatgpt']) {
       const response = await mcpRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }, path);
@@ -608,7 +627,7 @@ describe('Trac instance routing', () => {
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'WordPress Trac', version: '1.0.0' },
+          serverInfo: { name: 'WordPress Trac', version: '1.1.0' },
         },
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1297,7 +1297,7 @@ export async function handleMcpRequest(instance: TracInstance, request: JsonRpcR
         },
         serverInfo: {
           name: tracDisplayName(instance),
-          version: '1.0.0',
+          version: '1.1.0',
         },
       });
 
@@ -1493,7 +1493,7 @@ export async function handleChatGPTMcpRequest(instance: TracInstance, request: J
         },
         serverInfo: {
           name: tracDisplayName(instance),
-          version: '1.0.0',
+          version: '1.1.0',
         },
       });
 


### PR DESCRIPTION
Follow-up to the multi-instance change. Two unrelated-but-adjacent things, split by heading so either can be dropped.

## Version

Serving every WordPress.org Trac is a backward-compatible capability addition, so `1.0.0` → `1.1.0` in the registry entry, the package manifest, and the `serverInfo` both endpoints report. The version was already stated in four places and they are now consistent again.

## Documentation that did not match the code

- **README, Design and safety.** It said a redirect is reported as an unknown instance. Only a redirect that leaves the instance origin is; one that stays on it is reported as an upstream failure. This is in the security section, so the distinction is worth stating precisely.
- **Contributor guide, Change safely.** It said never let a filter reach Trac on a field the instance does not configure. The filtered query and the field check run concurrently, so the filter does reach Trac and the guard discards the response. The property actually worth guaranteeing is that results are never returned.
- **Testing guide.** It had no step for the filter rejection or the rejected instance paths, both of which the smoke-test checklist covers. The docs contributor guide says the two are one document split by audience and must agree, so this adds steps 11 and 12.

## Test

Adds the one redirect case with nothing behind it: a 3xx with no usable `Location` header has no target to compare against the instance origin, so it must stay a generic upstream failure rather than claim the Trac does not exist. Every existing redirect fixture sets a valid `Location`, so that null guard had no coverage.

I checked the test actually fails when the guard is removed, rather than trusting that it passes.

## Verification

`pnpm check` passes: 66 tests, TypeScript, Biome, both Worker dry-run builds.

The full manual smoke test, all seven sections, was run against production earlier today on the current build. These changes touch documentation, the version string, and one test, so no behavior moved.

One judgment call worth flagging: the package description drops `Core` to match the registry entry, which is a word outside the strict scope of this follow-up. Happy to pull it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)