### PR TITLE
Decode XML and HTML entities once each, after stripping tags

### DIFF
--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -73,7 +73,9 @@ Use these public tickets only. Each one is here because it covers a distinct par
 | `65808` | Linked pull request data present |
 | `65793` | Linked PR with no reviews; attachments kept separate from comments |
 | `62358` | Linked PR with no checks; changesets kept separate from comments |
+| `51407` | Escaped markup in a description; the text `<script>` inside a code span |
 | `r58504` | Changeset, with and without its diff |
+| `r62723` | Escaped markup in a changeset message; the same `<script>` text |
 | `99999999` | Nonexistent ticket and revision; the `not_found` tool error path |
 
 ```bash
@@ -84,8 +86,10 @@ call /mcp getTicket '{"id":65739,"includeComments":true}'
 call /mcp getTicket '{"id":65808}'
 call /mcp getTicket '{"id":65793}'
 call /mcp getTicket '{"id":62358}'
+call /mcp getTicket '{"id":51407,"includeComments":false}'
 call /mcp getChangeset '{"revision":58504,"includeDiff":false}'
 call /mcp getChangeset '{"revision":58504,"includeDiff":true,"diffLimit":500}'
+call /mcp getChangeset '{"revision":62723,"includeDiff":false}'
 call /mcp getTimeline '{"days":7,"limit":5}'
 call /mcp getTracInfo '{"type":"components"}'
 call /mcp getTracInfo '{"type":"milestones"}'
@@ -98,6 +102,7 @@ What to look for:
 - `getTicket` returns `id`, `title`, `text`, `url`, and `metadata`. With comments requested, `metadata` carries `comments`, `returnedComments`, and `totalComments`.
 - Tickets `65808`, `65793`, and `62358` each carry `metadata.linkedPullRequests`. `65793` also carries `metadata.attachments`, and `62358` also carries `metadata.changesets`, neither of them folded into the comment list.
 - `getChangeset` returns the revision, author, date, message, and file list. With `includeDiff`, the text includes diff hunks and respects `diffLimit`.
+- Ticket `51407` and changeset `r62723` both contain the literal text `<script>`, written on Trac inside a code span. Trac escapes it once for HTML and, in RSS, once more for XML. A missing `<script>` means the parser decoded a level too many before stripping tags and deleted the result.
 - `getTimeline` returns recent events, and `getTracInfo` returns the requested vocabulary. A seven day window is used because a quiet day can legitimately produce no events. An empty list is a valid answer for any short window, so judge this check on the request succeeding rather than on the count.
 
 ## 4. Pagination

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,6 +32,7 @@ Start the Worker by following [local-development.md](local-development.md), then
    - Read ticket `65808` and confirm its linked pull request data is present.
    - Read ticket `65793`; confirm linked pull request data remains available with no reviews and attachments are separate from comments.
    - Read ticket `62358`; confirm linked pull request data remains available with no checks and changesets are separate from comments.
+   - Read ticket `51407` and changeset `62723`; confirm the literal text `<script>` survives in both. Trac escapes it once for HTML and again for RSS, and decoding a level too many turns it into a tag the stripper removes.
    - Read changeset `58504` with and without its diff.
    - Read seven days of timeline activity. A short window can legitimately be empty, so judge this on the request succeeding rather than on the count.
    - List components and milestones.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -97,8 +97,14 @@ afterEach(() => {
 });
 
 describe('Trac parsing', () => {
-  it('cleans nested HTML entities and invisible characters', () => {
-    expect(cleanTracText('&lt;p&gt;It&#39;s clean&lt;/p&gt;\u200B')).toBe("It's clean");
+  it('strips tags and decodes HTML entities and invisible characters', () => {
+    expect(cleanTracText('<p>It&#39;s clean</p>\u200B')).toBe("It's clean");
+  });
+
+  it('keeps escaped markup in a code span as text', () => {
+    expect(cleanTracText('<p>Use <code>&lt;script&gt;</code> here.</p>')).toBe(
+      'Use <script> here.'
+    );
   });
 
   it('parses quoted CSV fields', () => {
@@ -479,6 +485,37 @@ describe('MCP transport', () => {
     expect(result.text).not.toContain('Slack mention.');
     expect(result.text).not.toContain('Pull request relay.');
     expect(result.text).not.toContain('Ticket description repeated.');
+  });
+
+  it('keeps escaped markup in the description and in comments', async () => {
+    const rss = `<?xml version="1.0"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/"><channel>
+      <description>&lt;p&gt;Sample: &lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;&lt;/p&gt;</description>
+      <item><dc:creator>reporter</dc:creator><pubDate>Wed, 05 Aug 2026 19:00:00 GMT</pubDate><title>status changed</title><link>https://core.trac.wordpress.org/ticket/51407#comment:2</link><description>&lt;ul&gt;&lt;li&gt;&lt;strong&gt;status&lt;/strong&gt; closed&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Also &lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;.&lt;/p&gt;</description></item>
+    </channel></rss>`;
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n51407,Script tag ticket,closed'))
+        .mockResolvedValueOnce(new Response(rss))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'getTicket',
+        arguments: { id: 51407, includeComments: true, commentLimit: 10 },
+      },
+    });
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(result.text).toContain('Sample: <script>');
+    expect(result.metadata.comments).toEqual([
+      expect.objectContaining({ id: 2, comment: 'Also <script>.' }),
+    ]);
   });
 
   it('requires an r prefix for changesets on the compatibility endpoint', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,52 +348,51 @@ type TicketChangeset = {
   url: string;
 };
 
-const HTML_ENTITIES: Record<string, string> = {
+/*
+ * Trac escapes its content once per format it passes through. An RSS item body is HTML
+ * escaped as XML, so `<code>&lt;script&gt;</code>` arrives as
+ * `&lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;`. Each level is undone by exactly one
+ * pass of the matching decoder, in order: XML when the item is read, HTML after the tags
+ * are stripped. Decoding twice, or decoding before stripping, turns escaped markup into a
+ * tag and the tag stripper then deletes it.
+ */
+const XML_ENTITIES: Record<string, string> = {
   amp: '&',
   apos: "'",
   gt: '>',
   lt: '<',
-  nbsp: ' ',
   quot: '"',
 };
 
-function decodeHtmlEntity(entity: string, code: string): string {
-  if (code[0] !== '#') {
-    return HTML_ENTITIES[code.toLowerCase()] ?? entity;
-  }
+const HTML_ENTITIES: Record<string, string> = { ...XML_ENTITIES, nbsp: ' ' };
 
-  const radix = code[1]?.toLowerCase() === 'x' ? 16 : 10;
-  const digits = radix === 16 ? code.slice(2) : code.slice(1);
-  const point = Number.parseInt(digits, radix);
-  return Number.isInteger(point) && point >= 0 && point <= 0x10ffff
-    ? String.fromCodePoint(point)
-    : entity;
+const ENTITY_REFERENCE = /&(#x[\da-f]+|#\d+|[a-z]+);/gi;
+
+function decodeEntities(value: string, named: Record<string, string>): string {
+  return value.replace(ENTITY_REFERENCE, (entity: string, code: string) => {
+    if (code[0] !== '#') {
+      return named[code.toLowerCase()] ?? entity;
+    }
+
+    const radix = code[1]?.toLowerCase() === 'x' ? 16 : 10;
+    const digits = radix === 16 ? code.slice(2) : code.slice(1);
+    const point = Number.parseInt(digits, radix);
+    return Number.isInteger(point) && point >= 0 && point <= 0x10ffff
+      ? String.fromCodePoint(point)
+      : entity;
+  });
+}
+
+function decodeXmlEntities(value: string): string {
+  return decodeEntities(value, XML_ENTITIES);
 }
 
 function decodeHtmlEntities(value: string): string {
-  let decoded = value;
-  for (let pass = 0; pass < 3; pass++) {
-    const next = decoded.replace(/&(#x[\da-f]+|#\d+|[a-z]+);/gi, decodeHtmlEntity);
-
-    if (next === decoded) {
-      break;
-    }
-    decoded = next;
-  }
-
-  return decoded;
+  return decodeEntities(value, HTML_ENTITIES);
 }
 
-export function cleanTracText(value: string): string {
-  let text = value.replace(/^<!\[CDATA\[([\s\S]*)\]\]>$/, '$1').replace(/^\uFEFF/, '');
-
-  text = decodeHtmlEntities(text)
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/(?:div|li|ol|p|pre|tr|ul)>/gi, '\n')
-    .replace(/<li[^>]*>/gi, '- ')
-    .replace(/<[^>]*>/g, '');
-
-  return decodeHtmlEntities(text)
+function normalizeTracText(value: string): string {
+  return value
     .replace(/[\u200B\uFEFF]/g, '')
     .replace(/\r/g, '')
     .replace(/[ \t]+\n/g, '\n')
@@ -402,21 +401,44 @@ export function cleanTracText(value: string): string {
     .trim();
 }
 
+/*
+ * Takes an HTML fragment and returns its text. Callers reading RSS must decode the XML
+ * level first, which `readXmlText` does.
+ */
+export function cleanTracText(html: string): string {
+  const text = html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:div|li|ol|p|pre|tr|ul)>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '- ')
+    .replace(/<[^>]*>/g, '');
+
+  return normalizeTracText(decodeHtmlEntities(text));
+}
+
 function extractXmlElement(source: string, tag: string): string {
   const match = source.match(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, 'i'));
   return match?.[1] ?? '';
 }
 
+// One XML decode, or none at all when the element carries its content as CDATA.
+function readXmlText(source: string, tag: string): string {
+  const raw = extractXmlElement(source, tag);
+  const cdata = raw.match(/^\s*<!\[CDATA\[([\s\S]*)\]\]>\s*$/);
+  return cdata?.[1] ?? decodeXmlEntities(raw);
+}
+
 function parseRssItems(rssText: string) {
   return Array.from(rssText.matchAll(/<item>([\s\S]*?)<\/item>/gi), (match) => {
     const item = match[1] ?? '';
+    const descriptionHtml = readXmlText(item, 'description');
     return {
-      title: cleanTracText(extractXmlElement(item, 'title')),
-      link: cleanTracText(extractXmlElement(item, 'link')),
-      description: cleanTracText(extractXmlElement(item, 'description')),
-      rawDescription: extractXmlElement(item, 'description'),
-      date: cleanTracText(extractXmlElement(item, 'pubDate')),
-      author: cleanTracText(extractXmlElement(item, 'dc:creator')),
+      // Trac writes these four as plain text, so the XML decode leaves nothing to strip.
+      title: normalizeTracText(readXmlText(item, 'title')),
+      link: normalizeTracText(readXmlText(item, 'link')),
+      date: normalizeTracText(readXmlText(item, 'pubDate')),
+      author: normalizeTracText(readXmlText(item, 'dc:creator')),
+      description: cleanTracText(descriptionHtml),
+      descriptionHtml,
     };
   });
 }
@@ -440,8 +462,7 @@ const TICKET_FIELDS = new Set([
   'version',
 ]);
 
-function splitTicketHistoryDescription(rawDescription: string) {
-  const html = decodeHtmlEntities(rawDescription);
+function splitTicketHistoryDescription(html: string) {
   const list = html.match(/^\s*<ul(?:\s[^>]*)?>([\s\S]*?)<\/ul>\s*/i);
   if (!list?.[0] || !list[1]) {
     return { html, body: cleanTracText(html) };
@@ -510,7 +531,7 @@ function classifyTicketHistoryItem(
     return null;
   }
 
-  const parsedDescription = splitTicketHistoryDescription(item.rawDescription);
+  const parsedDescription = splitTicketHistoryDescription(item.descriptionHtml);
   if (item.title.toLowerCase() === 'attachment set') {
     const filename = attachmentFilename(parsedDescription.html);
     return {
@@ -901,7 +922,7 @@ async function fetchTicket(
 
   const rssText = await rssResponse.text();
   const channel = rssText.split(/<item>/i, 1)[0] ?? '';
-  const description = cleanTracText(extractXmlElement(channel, 'description'));
+  const description = cleanTracText(readXmlText(channel, 'description'));
   const history = classifyTicketHistory(instance, ticketId, rssText);
   const limit = Math.min(Math.max(Math.trunc(commentLimit), 0), 50);
   const comments = includeComments && limit > 0 ? history.comments.slice(-limit) : [];


### PR DESCRIPTION
## What was wrong

Trac escapes content once for every format it passes through. An RSS item body is HTML that has been escaped as XML, so a description reading `<code>&lt;script&gt;</code>` arrives as `&lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;`.

`decodeHtmlEntities` looped up to three passes and ran before the tag stripper. Two passes turned the escaped `&lt;script&gt;` into a real `<script>` tag, and the stripper then deleted it. Reporters who quote markup in a code span lost exactly the text the ticket is about.

The loop existed because the decode ran twice on the same path: `splitTicketHistoryDescription` decoded the RSS body and handed the result to `cleanTracText`, which decoded it again.

## What changed

- `decodeXmlEntities` and `decodeHtmlEntities` are separate single-pass functions over the entity table each format defines. No loop.
- `readXmlText` performs the XML decode when an RSS element is read, and passes CDATA content through undecoded.
- `cleanTracText` takes an HTML fragment: strip tags, then decode once.
- RSS titles, links, dates, and authors are plain text after the XML decode, so they are whitespace-normalized instead of being run through the tag stripper, which used to eat any tag-like text in a ticket summary.

Two tests are added, one for a code span holding a tag and one for the RSS path that previously decoded twice. The existing entity test moves to the new `cleanTracText` contract, which takes HTML rather than an RSS fragment.

`docs/smoke-test.md` and `docs/testing.md` gain ticket `51407` and changeset `r62723` as fixtures for this case.

## How verified

`pnpm check` passes: type check, Biome, 78 tests, and both Worker dry-run builds.

Live checks against `pnpm dev`, per `docs/smoke-test.md`:

```
call /mcp getTicket '{"id":51407,"includeComments":false}'
  Description contains: Content-Security-Policy ... <script> ... (literal <script> present)
call /mcp getChangeset '{"revision":62723,"includeDiff":false}'
  Message contains: Replace the manually constructed <script> markup in _print_scripts()
call /mcp getTicket '{"id":59446,"includeComments":true,"commentLimit":20}'
  Description text intact; links are still stripped, which is #59
```

On `trunk` the first two return the same text with `<script>` missing.

Fixes #58
Part of #57
