### PR TITLE
Keep links in cleaned Trac text, with absolute hrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ ticket and an `r` prefix for a changeset: `65739` and `r58504`.
 No tool takes a Trac instance argument. The endpoint you connect to decides which Trac the tools
 read.
 
+Ticket and changeset text is plain text with one exception: links are kept as `<a href="...">`
+with an absolute URL, because a comment that points at a pull request or another ticket loses its
+point without one. Relative Trac links resolve against the instance you connected to.
+
 ### Search filters
 
 `searchTickets` accepts plain keywords, ticket numbers, or filter expressions joined with `&`:

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -74,6 +74,7 @@ Use these public tickets only. Each one is here because it covers a distinct par
 | `65793` | Linked PR with no reviews; attachments kept separate from comments |
 | `62358` | Linked PR with no checks; changesets kept separate from comments |
 | `51407` | Escaped markup in a description; the text `<script>` inside a code span |
+| `59446` | Links in a description and in comments |
 | `r58504` | Changeset, with and without its diff |
 | `r62723` | Escaped markup in a changeset message; the same `<script>` text |
 | `99999999` | Nonexistent ticket and revision; the `not_found` tool error path |
@@ -87,6 +88,7 @@ call /mcp getTicket '{"id":65808}'
 call /mcp getTicket '{"id":65793}'
 call /mcp getTicket '{"id":62358}'
 call /mcp getTicket '{"id":51407,"includeComments":false}'
+call /mcp getTicket '{"id":59446,"includeComments":true,"commentLimit":20}'
 call /mcp getChangeset '{"revision":58504,"includeDiff":false}'
 call /mcp getChangeset '{"revision":58504,"includeDiff":true,"diffLimit":500}'
 call /mcp getChangeset '{"revision":62723,"includeDiff":false}'
@@ -102,6 +104,7 @@ What to look for:
 - `getTicket` returns `id`, `title`, `text`, `url`, and `metadata`. With comments requested, `metadata` carries `comments`, `returnedComments`, and `totalComments`.
 - Tickets `65808`, `65793`, and `62358` each carry `metadata.linkedPullRequests`. `65793` also carries `metadata.attachments`, and `62358` also carries `metadata.changesets`, neither of them folded into the comment list.
 - `getChangeset` returns the revision, author, date, message, and file list. With `includeDiff`, the text includes diff hunks and respects `diffLimit`.
+- Ticket `59446` keeps its links as `<a href="...">` with absolute URLs. Its description links to an "existing PR" on GitHub and to an "example plugin". Text without the surrounding tag means links are being stripped again.
 - Ticket `51407` and changeset `r62723` both contain the literal text `<script>`, written on Trac inside a code span. Trac escapes it once for HTML and, in RSS, once more for XML. A missing `<script>` means the parser decoded a level too many before stripping tags and deleted the result.
 - `getTimeline` returns recent events, and `getTracInfo` returns the requested vocabulary. A seven day window is used because a quiet day can legitimately produce no events. An empty list is a valid answer for any short window, so judge this check on the request succeeding rather than on the count.
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -73,7 +73,9 @@ Use these public tickets only. Each one is here because it covers a distinct par
 | `65808` | Linked pull request data present |
 | `65793` | Linked PR with no reviews; attachments kept separate from comments |
 | `62358` | Linked PR with no checks; changesets kept separate from comments |
+| `51407` | Escaped markup in a description; the text `<script>` inside a code span |
 | `r58504` | Changeset, with and without its diff |
+| `r62723` | Escaped markup in a changeset message; the same `<script>` text |
 | `99999999` | Nonexistent ticket and revision; the `not_found` tool error path |
 
 ```bash
@@ -84,8 +86,10 @@ call /mcp getTicket '{"id":65739,"includeComments":true}'
 call /mcp getTicket '{"id":65808}'
 call /mcp getTicket '{"id":65793}'
 call /mcp getTicket '{"id":62358}'
+call /mcp getTicket '{"id":51407,"includeComments":false}'
 call /mcp getChangeset '{"revision":58504,"includeDiff":false}'
 call /mcp getChangeset '{"revision":58504,"includeDiff":true,"diffLimit":500}'
+call /mcp getChangeset '{"revision":62723,"includeDiff":false}'
 call /mcp getTimeline '{"days":7,"limit":5}'
 call /mcp getTracInfo '{"type":"components"}'
 call /mcp getTracInfo '{"type":"milestones"}'
@@ -98,6 +102,7 @@ What to look for:
 - `getTicket` returns `id`, `title`, `text`, `url`, and `metadata`. With comments requested, `metadata` carries `comments`, `returnedComments`, and `totalComments`.
 - Tickets `65808`, `65793`, and `62358` each carry `metadata.linkedPullRequests`. `65793` also carries `metadata.attachments`, and `62358` also carries `metadata.changesets`, neither of them folded into the comment list.
 - `getChangeset` returns the revision, author, date, message, and file list. With `includeDiff`, the text includes diff hunks and respects `diffLimit`.
+- Ticket `51407` and changeset `r62723` both contain the literal text `<script>`, written on Trac inside a code span. Trac escapes it once for HTML and, in RSS, once more for XML. A missing `<script>` means the parser decoded a level too many before stripping tags and deleted the result.
 - `getTimeline` returns recent events, and `getTracInfo` returns the requested vocabulary. A seven day window is used because a quiet day can legitimately produce no events. An empty list is a valid answer for any short window, so judge this check on the request succeeding rather than on the count.
 
 ## 4. Pagination

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,6 +32,7 @@ Start the Worker by following [local-development.md](local-development.md), then
    - Read ticket `65808` and confirm its linked pull request data is present.
    - Read ticket `65793`; confirm linked pull request data remains available with no reviews and attachments are separate from comments.
    - Read ticket `62358`; confirm linked pull request data remains available with no checks and changesets are separate from comments.
+   - Read ticket `59446` with comments; confirm the description and comments keep `<a href>` links with absolute URLs.
    - Read ticket `51407` and changeset `62723`; confirm the literal text `<script>` survives in both. Trac escapes it once for HTML and again for RSS, and decoding a level too many turns it into a tag the stripper removes.
    - Read changeset `58504` with and without its diff.
    - Read seven days of timeline activity. A short window can legitimately be empty, so judge this on the request succeeding rather than on the count.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,6 +32,7 @@ Start the Worker by following [local-development.md](local-development.md), then
    - Read ticket `65808` and confirm its linked pull request data is present.
    - Read ticket `65793`; confirm linked pull request data remains available with no reviews and attachments are separate from comments.
    - Read ticket `62358`; confirm linked pull request data remains available with no checks and changesets are separate from comments.
+   - Read ticket `51407` and changeset `62723`; confirm the literal text `<script>` survives in both. Trac escapes it once for HTML and again for RSS, and decoding a level too many turns it into a tag the stripper removes.
    - Read changeset `58504` with and without its diff.
    - Read seven days of timeline activity. A short window can legitimately be empty, so judge this on the request succeeding rather than on the count.
    - List components and milestones.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -97,8 +97,14 @@ afterEach(() => {
 });
 
 describe('Trac parsing', () => {
-  it('cleans nested HTML entities and invisible characters', () => {
-    expect(cleanTracText('&lt;p&gt;It&#39;s clean&lt;/p&gt;\u200B')).toBe("It's clean");
+  it('strips tags and decodes HTML entities and invisible characters', () => {
+    expect(cleanTracText('<p>It&#39;s clean</p>\u200B')).toBe("It's clean");
+  });
+
+  it('keeps escaped markup in a code span as text', () => {
+    expect(cleanTracText('<p>Use <code>&lt;script&gt;</code> here.</p>')).toBe(
+      'Use <script> here.'
+    );
   });
 
   it('parses quoted CSV fields', () => {
@@ -479,6 +485,37 @@ describe('MCP transport', () => {
     expect(result.text).not.toContain('Slack mention.');
     expect(result.text).not.toContain('Pull request relay.');
     expect(result.text).not.toContain('Ticket description repeated.');
+  });
+
+  it('keeps escaped markup in the description and in comments', async () => {
+    const rss = `<?xml version="1.0"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/"><channel>
+      <description>&lt;p&gt;Sample: &lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;&lt;/p&gt;</description>
+      <item><dc:creator>reporter</dc:creator><pubDate>Wed, 05 Aug 2026 19:00:00 GMT</pubDate><title>status changed</title><link>https://core.trac.wordpress.org/ticket/51407#comment:2</link><description>&lt;ul&gt;&lt;li&gt;&lt;strong&gt;status&lt;/strong&gt; closed&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Also &lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;.&lt;/p&gt;</description></item>
+    </channel></rss>`;
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n51407,Script tag ticket,closed'))
+        .mockResolvedValueOnce(new Response(rss))
+    );
+
+    const response = await mcpRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'getTicket',
+        arguments: { id: 51407, includeComments: true, commentLimit: 10 },
+      },
+    });
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(result.text).toContain('Sample: <script>');
+    expect(result.metadata.comments).toEqual([
+      expect.objectContaining({ id: 2, comment: 'Also <script>.' }),
+    ]);
   });
 
   it('requires an r prefix for changesets on the compatibility endpoint', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -98,13 +98,46 @@ afterEach(() => {
 
 describe('Trac parsing', () => {
   it('strips tags and decodes HTML entities and invisible characters', () => {
-    expect(cleanTracText('<p>It&#39;s clean</p>\u200B')).toBe("It's clean");
+    expect(cleanTracText('<p>It&#39;s clean</p>\u200B', CORE_TRAC.origin)).toBe("It's clean");
   });
 
   it('keeps escaped markup in a code span as text', () => {
-    expect(cleanTracText('<p>Use <code>&lt;script&gt;</code> here.</p>')).toBe(
+    expect(cleanTracText('<p>Use <code>&lt;script&gt;</code> here.</p>', CORE_TRAC.origin)).toBe(
       'Use <script> here.'
     );
+  });
+
+  it('keeps an external link without its class or icon span', () => {
+    expect(
+      cleanTracText(
+        '<p>See the <a class="ext-link" href="https://example.org/plugin"><span class="icon">\u200B</span>example plugin</a>.</p>',
+        CORE_TRAC.origin
+      )
+    ).toBe('See the <a href="https://example.org/plugin">example plugin</a>.');
+  });
+
+  it('keeps an internal ticket link without its class or title', () => {
+    expect(
+      cleanTracText(
+        '<p>In <a class="closed ticket" href="/ticket/58664" title="defect (bug): Adopt script helpers (closed: fixed)">#58664</a>.</p>',
+        CORE_TRAC.origin
+      )
+    ).toBe('In <a href="https://core.trac.wordpress.org/ticket/58664">#58664</a>.');
+  });
+
+  it('resolves a relative href from a field change against the instance', () => {
+    expect(
+      cleanTracText(
+        '<li><strong>description</strong> modified (<a href="/ticket/59446?action=diff&amp;version=6">diff</a>)</li>',
+        CORE_TRAC.origin
+      )
+    ).toBe(
+      '- description modified (<a href="https://core.trac.wordpress.org/ticket/59446?action=diff&version=6">diff</a>)'
+    );
+  });
+
+  it('drops an anchor that carries no href', () => {
+    expect(cleanTracText('<p><a name="top"></a>Top</p>', CORE_TRAC.origin)).toBe('Top');
   });
 
   it('parses quoted CSV fields', () => {
@@ -515,6 +548,42 @@ describe('MCP transport', () => {
     expect(result.text).toContain('Sample: <script>');
     expect(result.metadata.comments).toEqual([
       expect.objectContaining({ id: 2, comment: 'Also <script>.' }),
+    ]);
+  });
+
+  it('keeps comment links and resolves relative ones against the connected instance', async () => {
+    const rss = `<?xml version="1.0"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/"><channel>
+      <description>&lt;p&gt;See &lt;a class=&quot;ext-link&quot; href=&quot;https://github.com/WordPress/wordpress-develop/pull/1&quot;&gt;&lt;span class=&quot;icon&quot;&gt;​&lt;/span&gt;existing PR&lt;/a&gt;.&lt;/p&gt;</description>
+      <item><dc:creator>reviewer</dc:creator><pubDate>Wed, 05 Aug 2026 19:00:00 GMT</pubDate><title></title><link>https://meta.trac.wordpress.org/ticket/5483#comment:1</link><description>&lt;p&gt;Also &lt;a class=&quot;closed ticket&quot; href=&quot;/ticket/5480&quot; title=&quot;defect: something (closed: fixed)&quot;&gt;#5480&lt;/a&gt;.&lt;/p&gt;</description></item>
+    </channel></rss>`;
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response('id,summary,status\n5483,Meta ticket,new'))
+        .mockResolvedValueOnce(new Response(rss))
+        .mockResolvedValueOnce(Response.json([]))
+    );
+
+    const response = await mcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'getTicket', arguments: { id: 5483, includeComments: true } },
+      },
+      '/mcp/meta'
+    );
+    const body = (await response.json()) as RpcBody;
+    const result = JSON.parse(body.result.content.at(0)?.text ?? '{}');
+
+    expect(result.text).toContain(
+      'See <a href="https://github.com/WordPress/wordpress-develop/pull/1">existing PR</a>.'
+    );
+    expect(result.metadata.comments).toEqual([
+      expect.objectContaining({
+        comment: 'Also <a href="https://meta.trac.wordpress.org/ticket/5480">#5480</a>.',
+      }),
     ]);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,52 +348,51 @@ type TicketChangeset = {
   url: string;
 };
 
-const HTML_ENTITIES: Record<string, string> = {
+/*
+ * Trac escapes its content once per format it passes through. An RSS item body is HTML
+ * escaped as XML, so `<code>&lt;script&gt;</code>` arrives as
+ * `&lt;code&gt;&amp;lt;script&amp;gt;&lt;/code&gt;`. Each level is undone by exactly one
+ * pass of the matching decoder, in order: XML when the item is read, HTML after the tags
+ * are stripped. Decoding twice, or decoding before stripping, turns escaped markup into a
+ * tag and the tag stripper then deletes it.
+ */
+const XML_ENTITIES: Record<string, string> = {
   amp: '&',
   apos: "'",
   gt: '>',
   lt: '<',
-  nbsp: ' ',
   quot: '"',
 };
 
-function decodeHtmlEntity(entity: string, code: string): string {
-  if (code[0] !== '#') {
-    return HTML_ENTITIES[code.toLowerCase()] ?? entity;
-  }
+const HTML_ENTITIES: Record<string, string> = { ...XML_ENTITIES, nbsp: ' ' };
 
-  const radix = code[1]?.toLowerCase() === 'x' ? 16 : 10;
-  const digits = radix === 16 ? code.slice(2) : code.slice(1);
-  const point = Number.parseInt(digits, radix);
-  return Number.isInteger(point) && point >= 0 && point <= 0x10ffff
-    ? String.fromCodePoint(point)
-    : entity;
+const ENTITY_REFERENCE = /&(#x[\da-f]+|#\d+|[a-z]+);/gi;
+
+function decodeEntities(value: string, named: Record<string, string>): string {
+  return value.replace(ENTITY_REFERENCE, (entity: string, code: string) => {
+    if (code[0] !== '#') {
+      return named[code.toLowerCase()] ?? entity;
+    }
+
+    const radix = code[1]?.toLowerCase() === 'x' ? 16 : 10;
+    const digits = radix === 16 ? code.slice(2) : code.slice(1);
+    const point = Number.parseInt(digits, radix);
+    return Number.isInteger(point) && point >= 0 && point <= 0x10ffff
+      ? String.fromCodePoint(point)
+      : entity;
+  });
+}
+
+function decodeXmlEntities(value: string): string {
+  return decodeEntities(value, XML_ENTITIES);
 }
 
 function decodeHtmlEntities(value: string): string {
-  let decoded = value;
-  for (let pass = 0; pass < 3; pass++) {
-    const next = decoded.replace(/&(#x[\da-f]+|#\d+|[a-z]+);/gi, decodeHtmlEntity);
-
-    if (next === decoded) {
-      break;
-    }
-    decoded = next;
-  }
-
-  return decoded;
+  return decodeEntities(value, HTML_ENTITIES);
 }
 
-export function cleanTracText(value: string): string {
-  let text = value.replace(/^<!\[CDATA\[([\s\S]*)\]\]>$/, '$1').replace(/^\uFEFF/, '');
-
-  text = decodeHtmlEntities(text)
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/(?:div|li|ol|p|pre|tr|ul)>/gi, '\n')
-    .replace(/<li[^>]*>/gi, '- ')
-    .replace(/<[^>]*>/g, '');
-
-  return decodeHtmlEntities(text)
+function normalizeTracText(value: string): string {
+  return value
     .replace(/[\u200B\uFEFF]/g, '')
     .replace(/\r/g, '')
     .replace(/[ \t]+\n/g, '\n')
@@ -402,21 +401,44 @@ export function cleanTracText(value: string): string {
     .trim();
 }
 
+/*
+ * Takes an HTML fragment and returns its text. Callers reading RSS must decode the XML
+ * level first, which `readXmlText` does.
+ */
+export function cleanTracText(html: string): string {
+  const text = html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:div|li|ol|p|pre|tr|ul)>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '- ')
+    .replace(/<[^>]*>/g, '');
+
+  return normalizeTracText(decodeHtmlEntities(text));
+}
+
 function extractXmlElement(source: string, tag: string): string {
   const match = source.match(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, 'i'));
   return match?.[1] ?? '';
 }
 
+// One XML decode, or none at all when the element carries its content as CDATA.
+function readXmlText(source: string, tag: string): string {
+  const raw = extractXmlElement(source, tag);
+  const cdata = raw.match(/^\s*<!\[CDATA\[([\s\S]*)\]\]>\s*$/);
+  return cdata?.[1] ?? decodeXmlEntities(raw);
+}
+
 function parseRssItems(rssText: string) {
   return Array.from(rssText.matchAll(/<item>([\s\S]*?)<\/item>/gi), (match) => {
     const item = match[1] ?? '';
+    const descriptionHtml = readXmlText(item, 'description');
     return {
-      title: cleanTracText(extractXmlElement(item, 'title')),
-      link: cleanTracText(extractXmlElement(item, 'link')),
-      description: cleanTracText(extractXmlElement(item, 'description')),
-      rawDescription: extractXmlElement(item, 'description'),
-      date: cleanTracText(extractXmlElement(item, 'pubDate')),
-      author: cleanTracText(extractXmlElement(item, 'dc:creator')),
+      // Trac writes these four as plain text, so the XML decode leaves nothing to strip.
+      title: normalizeTracText(readXmlText(item, 'title')),
+      link: normalizeTracText(readXmlText(item, 'link')),
+      date: normalizeTracText(readXmlText(item, 'pubDate')),
+      author: normalizeTracText(readXmlText(item, 'dc:creator')),
+      description: cleanTracText(descriptionHtml),
+      descriptionHtml,
     };
   });
 }
@@ -440,8 +462,7 @@ const TICKET_FIELDS = new Set([
   'version',
 ]);
 
-function splitTicketHistoryDescription(rawDescription: string) {
-  const html = decodeHtmlEntities(rawDescription);
+function splitTicketHistoryDescription(html: string) {
   const list = html.match(/^\s*<ul(?:\s[^>]*)?>([\s\S]*?)<\/ul>\s*/i);
   if (!list?.[0] || !list[1]) {
     return { html, body: cleanTracText(html) };
@@ -510,7 +531,7 @@ function classifyTicketHistoryItem(
     return null;
   }
 
-  const parsedDescription = splitTicketHistoryDescription(item.rawDescription);
+  const parsedDescription = splitTicketHistoryDescription(item.descriptionHtml);
   if (item.title.toLowerCase() === 'attachment set') {
     const filename = attachmentFilename(parsedDescription.html);
     return {
@@ -901,7 +922,7 @@ async function fetchTicket(
 
   const rssText = await rssResponse.text();
   const channel = rssText.split(/<item>/i, 1)[0] ?? '';
-  const description = cleanTracText(extractXmlElement(channel, 'description'));
+  const description = cleanTracText(readXmlText(channel, 'description'));
   const history = classifyTicketHistory(instance, ticketId, rssText);
   const limit = Math.min(Math.max(Math.trunc(commentLimit), 0), 50);
   const comments = includeComments && limit > 0 ? history.comments.slice(-limit) : [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,15 +402,56 @@ function normalizeTracText(value: string): string {
 }
 
 /*
- * Takes an HTML fragment and returns its text. Callers reading RSS must decode the XML
- * level first, which `readXmlText` does.
+ * Trac decorates every link it renders: `class` for styling, `title` with a summary of the
+ * target, and an empty `<span class="icon">` before external link text. None of that helps a
+ * reader, so only the href is kept. Hrefs stay entity-encoded here because the whole text is
+ * decoded once at the end.
  */
-export function cleanTracText(html: string): string {
+function rewriteAnchor(tag: string, origin: string): string {
+  const href = tag.match(/\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/i);
+  const target = href?.[1] ?? href?.[2] ?? href?.[3];
+  if (!target) {
+    return '';
+  }
+
+  try {
+    return `<a href="${new URL(target, origin).href}">`;
+  } catch {
+    return '';
+  }
+}
+
+/*
+ * Takes an HTML fragment and returns text, keeping links as `<a href>` with an absolute URL.
+ * Agents read HTML, and a Trac comment that points at a pull request or another ticket loses
+ * its point when the URL goes. Callers reading RSS must decode the XML level first, which
+ * `readXmlText` does.
+ */
+export function cleanTracText(html: string, origin: string): string {
+  const anchors: boolean[] = [];
   const text = html
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/(?:div|li|ol|p|pre|tr|ul)>/gi, '\n')
-    .replace(/<li[^>]*>/gi, '- ')
-    .replace(/<[^>]*>/g, '');
+    .replace(/<span\s[^>]*class=["']?icon["']?[^>]*>[\s\S]*?<\/span>/gi, '')
+    .replace(/<[^>]*>/g, (tag) => {
+      if (/^<br\s*\/?>$/i.test(tag)) {
+        return '\n';
+      }
+      if (/^<\/(?:div|li|ol|p|pre|tr|ul)>$/i.test(tag)) {
+        return '\n';
+      }
+      if (/^<li[\s>]/i.test(tag)) {
+        return '- ';
+      }
+      if (/^<a[\s>]/i.test(tag)) {
+        const anchor = rewriteAnchor(tag, origin);
+        anchors.push(anchor !== '');
+        return anchor;
+      }
+      // An unbalanced `</a>` closes nothing; drop it with the rest of the markup.
+      if (/^<\/a\s*>$/i.test(tag)) {
+        return anchors.pop() ? '</a>' : '';
+      }
+      return '';
+    });
 
   return normalizeTracText(decodeHtmlEntities(text));
 }
@@ -427,7 +468,7 @@ function readXmlText(source: string, tag: string): string {
   return cdata?.[1] ?? decodeXmlEntities(raw);
 }
 
-function parseRssItems(rssText: string) {
+function parseRssItems(rssText: string, origin: string) {
   return Array.from(rssText.matchAll(/<item>([\s\S]*?)<\/item>/gi), (match) => {
     const item = match[1] ?? '';
     const descriptionHtml = readXmlText(item, 'description');
@@ -437,7 +478,7 @@ function parseRssItems(rssText: string) {
       link: normalizeTracText(readXmlText(item, 'link')),
       date: normalizeTracText(readXmlText(item, 'pubDate')),
       author: normalizeTracText(readXmlText(item, 'dc:creator')),
-      description: cleanTracText(descriptionHtml),
+      description: cleanTracText(descriptionHtml, origin),
       descriptionHtml,
     };
   });
@@ -462,10 +503,10 @@ const TICKET_FIELDS = new Set([
   'version',
 ]);
 
-function splitTicketHistoryDescription(html: string) {
+function splitTicketHistoryDescription(html: string, origin: string) {
   const list = html.match(/^\s*<ul(?:\s[^>]*)?>([\s\S]*?)<\/ul>\s*/i);
   if (!list?.[0] || !list[1]) {
-    return { html, body: cleanTracText(html) };
+    return { html, body: cleanTracText(html, origin) };
   }
 
   const items = Array.from(list[1].matchAll(/<li(?:\s[^>]*)?>[\s\S]*?<\/li>/gi), (match) =>
@@ -480,11 +521,11 @@ function splitTicketHistoryDescription(html: string) {
     items.length === 0 ||
     items.some((field) => !field || !TICKET_FIELDS.has(field))
   ) {
-    return { html, body: cleanTracText(html) };
+    return { html, body: cleanTracText(html, origin) };
   }
 
   const narrativeHtml = html.slice(list[0].length);
-  return { html, body: cleanTracText(narrativeHtml), narrativeHtml };
+  return { html, body: cleanTracText(narrativeHtml, origin), narrativeHtml };
 }
 
 function filterTicketFieldChurn(changes: string): string {
@@ -505,12 +546,12 @@ function filterTicketFieldChurn(changes: string): string {
     .join('; ');
 }
 
-function attachmentFilename(html: string): string {
+function attachmentFilename(html: string, origin: string): string {
   const emphasized = html.match(/<em(?:\s[^>]*)?>([\s\S]*?)<\/em>/i)?.[1];
   const fieldValue = html.match(
     /<strong(?:\s[^>]*)?>\s*attachment\s*<\/strong>[\s\S]*?<span\s+class=["']trac-field-new["'][^>]*>([\s\S]*?)<\/span>/i
   )?.[1];
-  return cleanTracText(emphasized ?? fieldValue ?? '');
+  return cleanTracText(emphasized ?? fieldValue ?? '', origin);
 }
 
 type RssItem = ReturnType<typeof parseRssItems>[number];
@@ -531,9 +572,9 @@ function classifyTicketHistoryItem(
     return null;
   }
 
-  const parsedDescription = splitTicketHistoryDescription(item.descriptionHtml);
+  const parsedDescription = splitTicketHistoryDescription(item.descriptionHtml, instance.origin);
   if (item.title.toLowerCase() === 'attachment set') {
-    const filename = attachmentFilename(parsedDescription.html);
+    const filename = attachmentFilename(parsedDescription.html, instance.origin);
     return {
       kind: 'attachment',
       entry: {
@@ -561,7 +602,7 @@ function classifyTicketHistoryItem(
         author: item.author,
         timestamp: item.date,
         changes: filterTicketFieldChurn(item.title),
-        message: cleanTracText(narrativeHtml.slice(changesetMatch[0].length)),
+        message: cleanTracText(narrativeHtml.slice(changesetMatch[0].length), instance.origin),
         url: `${instance.origin}/changeset/${revision}`,
       },
     };
@@ -590,7 +631,7 @@ function classifyTicketHistory(instance: TracInstance, ticketId: number, rssText
   const attachments: TicketAttachment[] = [];
   const changesets: TicketChangeset[] = [];
 
-  for (const item of parseRssItems(rssText)) {
+  for (const item of parseRssItems(rssText, instance.origin)) {
     const classified = classifyTicketHistoryItem(instance, ticketId, item);
     if (classified?.kind === 'comment') {
       comments.push(classified.entry);
@@ -922,7 +963,7 @@ async function fetchTicket(
 
   const rssText = await rssResponse.text();
   const channel = rssText.split(/<item>/i, 1)[0] ?? '';
-  const description = cleanTracText(readXmlText(channel, 'description'));
+  const description = cleanTracText(readXmlText(channel, 'description'), instance.origin);
   const history = classifyTicketHistory(instance, ticketId, rssText);
   const limit = Math.min(Math.max(Math.trunc(commentLimit), 0), 50);
   const comments = includeComments && limit > 0 ? history.comments.slice(-limit) : [];
@@ -1068,17 +1109,21 @@ async function fetchChangeset(
 
   const html = await response.text();
   const message = cleanTracText(
-    html.match(/<dd class="message[^"]*"[^>]*>([\s\S]*?)<\/dd>/i)?.[1] ?? ''
+    html.match(/<dd class="message[^"]*"[^>]*>([\s\S]*?)<\/dd>/i)?.[1] ?? '',
+    instance.origin
   );
-  const author = cleanTracText(html.match(/<dd class="author"[^>]*>([\s\S]*?)<\/dd>/i)?.[1] ?? '');
+  const author = cleanTracText(
+    html.match(/<dd class="author"[^>]*>([\s\S]*?)<\/dd>/i)?.[1] ?? '',
+    instance.origin
+  );
   const date =
-    cleanTracText(html.match(/<dd class="time"[^>]*>([\s\S]*?)<\/dd>/i)?.[1] ?? '')
+    cleanTracText(html.match(/<dd class="time"[^>]*>([\s\S]*?)<\/dd>/i)?.[1] ?? '', instance.origin)
       .split('\n')[0]
       ?.trim() ?? '';
   const filesSection = html.match(/<dd class="files"[^>]*>([\s\S]*?)<\/ul>\s*<\/dd>/i)?.[1] ?? '';
   const files = Array.from(
     filesSection.matchAll(/<a[^>]*href="\/browser\/[^"]*"[^>]*>([\s\S]*?)<\/a>/gi),
-    (match) => cleanTracText(match[1] ?? '')
+    (match) => cleanTracText(match[1] ?? '', instance.origin)
   ).filter(Boolean);
 
   let diff = '';
@@ -1164,7 +1209,7 @@ async function fetchTracFieldOptions(
 
   return {
     data: Array.from(select.matchAll(/<option[^>]*value="([^"]+)"[^>]*>/gi), (match) =>
-      cleanTracText(match[1] ?? '')
+      cleanTracText(match[1] ?? '', instance.origin)
     ).filter(Boolean),
     configured: true,
   };
@@ -1225,7 +1270,7 @@ async function fetchTimeline(instance: TracInstance, days: number, limit: number
     throw upstreamHttpError(response, `Failed to fetch timeline: ${response.statusText}`);
   }
 
-  return parseRssItems(await response.text()).map((item, index) => ({
+  return parseRssItems(await response.text(), instance.origin).map((item, index) => ({
     id: item.link || `event-${index}`,
     title: item.title || 'Unknown Event',
     text: `${item.title || 'Unknown Event'}\n\nAuthor: ${item.author || 'Unknown'}\nDate: ${item.date || 'Unknown'}\n\n${item.description || 'No description available'}`,


### PR DESCRIPTION
Stacked on #61. GitHub cannot use a fork branch as a base, so this pull request targets `trunk` and its diff includes #61 until that merges. The commit to review here is the second one.

## What was wrong

`cleanTracText` deleted `<a>` along with every other tag. A comment reading "see the existing PR" arrived with no URL, and neither did the ticket cross-references that carry most of the context on an old ticket. Ticket 59446 loses 28 links that way.

Trac decorates the links it renders:

```html
<a class="ext-link" href="https://github.com/…"><span class="icon">&#8203;</span>existing PR</a>
<a class="closed ticket" href="/ticket/58664" title="defect (bug): … (closed: fixed)">#58664</a>
```

Field-change items and the changeset page use relative hrefs, which mean nothing once the text leaves the page they came from.

## What changed

- Anchors survive tag stripping as `<a href="...">text</a>`. Agents read HTML, so the tag is more useful than a rewrite into another link syntax.
- `class`, `title`, and the empty `<span class="icon">` are dropped. None of them tells a reader anything the href and the text do not.
- Hrefs are resolved with `new URL(href, origin)`. `cleanTracText` takes the origin as a second argument, threaded from the connected instance, so a relative link read through `/mcp/meta` resolves to Meta and not to Core.
- An anchor with no usable href is unwrapped, and its closing tag goes with it, so no unbalanced markup reaches the output.

Tests cover an external link with its icon span, an internal ticket link with `class` and `title`, a relative href from a field-change item, an anchor without an href, and the instance threading through `getTicket` on `/mcp/meta`.

`README.md`, `docs/smoke-test.md`, and `docs/testing.md` record the output contract and add ticket `59446` as a fixture.

## How verified

`pnpm check` passes: type check, Biome, 82 tests, and both Worker dry-run builds.

Live check against `pnpm dev`, per `docs/smoke-test.md`:

```
call /mcp getTicket '{"id":59446,"includeComments":true,"commentLimit":20}'
  28 links, all absolute, 28 opening and 28 closing tags. Among them:
  <a href="https://github.com/WordPress/wordpress-develop/pull/498">existing PR</a>
  <a href="https://github.com/westonruter/strict-csp">example plugin</a>
  <a href="https://core.trac.wordpress.org/ticket/58664">#58664</a>
call /mcp getTicket '{"id":51407,"includeComments":false}'
  Description keeps the literal text <script> (the #61 case, unchanged here)
call /mcp getChangeset '{"revision":62723,"includeDiff":false}'
  Message keeps the literal text <script>
```

On `trunk` the 59446 call returns the same prose with every link gone.

Fixes #59
Part of #57
